### PR TITLE
Re-structure to have image and content side-by-side

### DIFF
--- a/WeddingWebsite/Components/WeddingComponents/WeddingPartyIntroduction.razor
+++ b/WeddingWebsite/Components/WeddingComponents/WeddingPartyIntroduction.razor
@@ -4,22 +4,25 @@
 @using WeddingWebsite.Components.Containers
 
 <OutlinedBox>
+    <div class="name-and-role">
+        <h3 class="name">@Person.Name</h3>
+        <p class="role">@Person.Role.GetEnumDescription()</p>
+    </div>
     <div class="inner-container">
         <div class="media">
             <WebsiteElement Element="@Person.Media" MaxHeight="100%"/>
         </div>
-        <div class="name-and-role">
-            <h3 class="name">@Person.Name</h3>
-            <p class="role">@Person.Role.GetEnumDescription()</p>
+        <div class="right-content">
+
+            @foreach (var sect in Person.Content) {
+                @if (sect.Heading == null) {
+                    <p>@sect.CollapseContent()</p>
+                }
+                else {
+                    <p><b>@sect.Heading: </b>@sect.CollapseContent()</p>
+                }
+            }
         </div>
-        @foreach (var sect in Person.Content) {
-            @if (sect.Heading == null) {
-                <p>@sect.CollapseContent()</p>
-            }
-            else {
-                <p><b>@sect.Heading: </b>@sect.CollapseContent()</p>
-            }
-        }
     </div>
 </OutlinedBox>
 

--- a/WeddingWebsite/Components/WeddingComponents/WeddingPartyIntroduction.razor.css
+++ b/WeddingWebsite/Components/WeddingComponents/WeddingPartyIntroduction.razor.css
@@ -1,15 +1,18 @@
 ﻿.inner-container {
     padding: 10px;
     display: flex;
-    flex-direction: column;
-    height: 400px;
+    flex-direction: row;
 }
 
 .media {
-    flex: 1;
-    min-height: 0;
-    min-width: 0;
+    max-height: 200px;
+    width: 150px;
+    object-fit: contain;
     margin-bottom: 10px;
+}
+
+.right-content {
+    flex: 1;
 }
 
 .name-and-role {


### PR DESCRIPTION
# What does this PR do, and why do we need it?
The old design is too big:
<img width="1266" height="790" alt="image" src="https://github.com/user-attachments/assets/f0809340-7ae3-4a5b-8123-58bf73201eac" />

This PR conserves vertical space by moving the image beside the content:
<img width="1256" height="811" alt="image" src="https://github.com/user-attachments/assets/6613b5c2-d337-4445-99d6-7c5b0d334722" />

# Does this affect the IWeddingDetails interface?
No

# Are you overriding the default behaviour, or have you added it behind a config option?
Overriding default behaviour as the old design is too space inefficient to be wanted by anyone.

# Any other comments?
Will shrink a bit nicer on mobile too.
