### PR TITLE
Fix modal spacing

### DIFF
--- a/WeddingWebsite/Components/Dialogs/EventDialog.razor
+++ b/WeddingWebsite/Components/Dialogs/EventDialog.razor
@@ -5,7 +5,6 @@
         @if (Content != null)
         @foreach (var sect in Content) {
             <h3>@sect.Heading</h3>
-            @* TODO: Limit max height of website elements *@
             <WebsiteElement Element=@sect.Media MaxHeight="250px" />
             @foreach (var paragraph in sect.Content) {
                 <p>@paragraph</p>

--- a/WeddingWebsite/Components/Dialogs/EventDialog.razor.css
+++ b/WeddingWebsite/Components/Dialogs/EventDialog.razor.css
@@ -1,0 +1,8 @@
+﻿h3 {
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+p {
+    margin-bottom: 5px;
+}

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -26,10 +26,44 @@ public class SampleWeddingDetails : IWeddingDetails
         // Cannot access venues in static context
         Events = new List<Event>
         {
-            new ("Ceremony", TimeOnly.Parse("12:00"), TimeOnly.Parse("13:00"), "The church service in which we get married.", CeremonyVenue, new WebsiteImage("https://www.wedgewoodweddings.com/hubfs/3.0%20Feature%20Images%201000%20x%20500%20px/Blog/Lets%20Talk%20About%20Beach%20Weddings.png", "A wedding ceremony on a beach")),
-            new ("Drinks Reception", TimeOnly.Parse("13:30"), TimeOnly.Parse("15:00"), "Join us for drinks and canapés in the garden.", ReceptionVenue, new WebsiteImage("https://www.confetti.co.uk/blog/wp-content/uploads/2013/04/alitrystan39.jpg", "Some bottles of champagne surrounded by lots of empty glasses")),
-            new ("Wedding Breakfast", TimeOnly.Parse("15:30"), TimeOnly.Parse("18:00"), "A sit-down meal with speeches and toasts.", ReceptionVenue, new WebsiteImage("https://wpmedia.bridebook.com/wp-content/uploads/2024/12/tTqnnv01-858154ee-97ae-4e73-ab3c-ccc28bdeb395.jpg", "A long table with guests eating food"), null, [new WeddingModal("View Menu", [new ("Main Course", "Roast chicken, potatoes and vegetables")])]),
-            new ("Evening Reception", TimeOnly.Parse("19:00"), TimeOnly.Parse("23:00"), "An evening of dancing and celebration.", ReceptionVenue, new WebsiteImage("https://images.squarespace-cdn.com/content/v1/5f5afb7d868b466f42d4b4fb/77e1c31d-3913-4202-bd13-e5ce142a1f7f/wedding-dance-floor-playlist-20.png", "Guests dancing at a wedding"))
+            new (
+                "Ceremony", 
+                TimeOnly.Parse("12:00"), 
+                TimeOnly.Parse("13:00"), 
+                "The church service in which we get married.",
+                CeremonyVenue, 
+                new WebsiteImage("https://www.wedgewoodweddings.com/hubfs/3.0%20Feature%20Images%201000%20x%20500%20px/Blog/Lets%20Talk%20About%20Beach%20Weddings.png", "A wedding ceremony on a beach")
+            ),
+            new (
+                "Drinks Reception", 
+                TimeOnly.Parse("13:30"),
+                TimeOnly.Parse("15:00"), 
+                "Join us for drinks and canapés in the garden.", 
+                ReceptionVenue, 
+                new WebsiteImage("https://www.confetti.co.uk/blog/wp-content/uploads/2013/04/alitrystan39.jpg", "Some bottles of champagne surrounded by lots of empty glasses")
+                ),
+            new (
+                "Wedding Breakfast", 
+                TimeOnly.Parse("15:30"), 
+                TimeOnly.Parse("18:00"),
+                "A sit-down meal with speeches and toasts.", 
+                ReceptionVenue, 
+                new WebsiteImage("https://wpmedia.bridebook.com/wp-content/uploads/2024/12/tTqnnv01-858154ee-97ae-4e73-ab3c-ccc28bdeb395.jpg", "A long table with guests eating food"), 
+                null, 
+                [
+                    new WeddingModal("View Menu", [
+                        new ("Main Course", "Roast chicken, potatoes and vegetables")
+                    ])
+                ]
+            ),
+            new (
+                "Evening Reception", 
+                TimeOnly.Parse("19:00"),
+                TimeOnly.Parse("23:00"),
+                "An evening of dancing and celebration.", 
+                ReceptionVenue, 
+                new WebsiteImage("https://images.squarespace-cdn.com/content/v1/5f5afb7d868b466f42d4b4fb/77e1c31d-3913-4202-bd13-e5ce142a1f7f/wedding-dance-floor-playlist-20.png", "Guests dancing at a wedding")
+            )
         };
     }
 

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -201,7 +201,10 @@ public class SampleWeddingDetails : IWeddingDetails
         new Location(48.8584196, 2.2943747), 
         "123 Paradise Lane, Eden, ED1 2AB",
         new TravelDirections(
-            "<p>We suggest arriving by foot.</p><p><b>Parking: </b>There is no parking available, except for blue badge holders.</p>",
+            [
+                new WebsiteSection(null, "We suggest arriving by foot."),
+                new WebsiteSection("Parking", "There is no parking available, except for blue badge holders.")
+            ],
             null,
             20
         )
@@ -212,8 +215,10 @@ public class SampleWeddingDetails : IWeddingDetails
         new Location(12345, 67890), 
         "456 Holy Road, Eden, ED3 4GH",
         new TravelDirections(
-            @"<p>We suggest arriving by car. If you do not have a car, please let us know when you RSVP and we can arrange a lift for you.</p>
-                        <p><b>Parking: </b>Please follow the signs to car parking. Please do not park in the spaces directly outside the entrance unless you are a blue badge holder, or have been informed directly that you may park there.</p>",
+            [
+                new WebsiteSection(null, "We suggest arriving by car. If you do not have a car, please let us know when you RSPV and we can arrange a lift for you."),
+                new WebsiteSection("Parking", "Please follow the signs to car parking. Please do not park in the spaces directly outside the entrance unless you are a blue badge holder, or have been informed directly that you may park there.")
+            ],
             null,
             null,
             new WebsiteImage("https://www.instant-quote.co/images/cars/large/o_1ikkmciu01pgc1uko1lh71o60j0p1c.jpeg", "A wedding car")

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -52,7 +52,9 @@ public class SampleWeddingDetails : IWeddingDetails
                 null, 
                 [
                     new WeddingModal("View Menu", [
-                        new ("Main Course", "Roast chicken, potatoes and vegetables")
+                        new ("Starter", "Avocado and prawns"),
+                        new ("Main Course", "Roast chicken, potatoes and vegetables"),
+                        new ("Dessert", "Trio of chocolate brownie, lemon posset and creme brulee")
                     ])
                 ]
             ),


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Fixes not having any space between the text in modals.

Old:
<img width="450" height="294" alt="image" src="https://github.com/user-attachments/assets/0db672d7-16b8-46db-a8e9-e146b888a04d" />

New:
<img width="450" height="320" alt="image" src="https://github.com/user-attachments/assets/baaf2635-c5e0-471b-9246-f605e55eb55c" />

## Does this affect the IWeddingDetails interface?
No.

## Are you overriding the default behaviour, or have you added it behind a config option?
Overriding default behaviour because this is a definite upgrade.

## Does any validation logic need adding/updating?
No.

## Any other comments?
No.

## Does this close any issues?
Closes #11