### PR TITLE
Improve login page

### DIFF
--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -2,16 +2,20 @@
 
 @using System.ComponentModel.DataAnnotations
 @using Microsoft.AspNetCore.Authentication
-@using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Identity
+@using WeddingWebsite.Components.Containers
 @using WeddingWebsite.Core
 @using WeddingWebsite.Data
+@using WeddingWebsite.Models.Theme
+@using WeddingWebsite.Models.WebsiteConfig
+@using WeddingWebsite.Models.WeddingDetails
 
 @inject SignInManager<Account> SignInManager
 @inject ILogger<Login> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
 @inject IWeddingDetails WeddingDetails
+@inject IWebsiteConfig Config
 
 @attribute [AllowAnonymous]
 
@@ -20,50 +24,54 @@
 <img class="background-image" src="@WeddingDetails.MainImage.Url" alt="@WeddingDetails.MainImage.AltText"/>
 
 <div class="container">
-    <section class="login-modal">
-        <h1>Log in</h1>
-        <p>@errorMessage</p>
-        <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
-            <DataAnnotationsValidator />
-            <hr />
-            <ValidationSummary class="text-danger" role="alert" />
-            <div>
-                <label for="email" class="form-label">Email</label>
-                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <ValidationMessage For="() => Input.Email" class="text-danger" />
-            </div>
-            <div>
-                <label for="password" class="form-label">Password</label>
-                <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
-                <ValidationMessage For="() => Input.Password" class="text-danger" />
-            </div>
-            <div>
-                <label class="form-label">
-                    <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input" />
-                    Remember me
-                </label>
-            </div>
-            <div>
-                <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-            </div>
-            <p>Forgot your password? Please contact me to reset it.</p>
-            @* <div> *@
-            @*     <p> *@
-            @*         <a href="Account/ForgotPassword">Forgot your password?</a> *@
-            @*     </p> *@
-            @*     <p> *@
-            @*         <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Register as a new user</a> *@
-            @*     </p> *@
-            @*     <p> *@
-            @*         <a href="Account/ResendEmailConfirmation">Resend email confirmation</a> *@
-            @*     </p> *@
-            @* </div> *@
-        </EditForm>
-    </section>
+    <CascadingValue Value="ModalTheme">
+        <Box>
+            <h1>Log in</h1>
+            <p>@errorMessage</p>
+            <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
+                <DataAnnotationsValidator/>
+                <hr/>
+                <ValidationSummary class="text-danger" role="alert"/>
+                <div>
+                    <label for="email" class="form-label">Email</label>
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com"/>
+                    <ValidationMessage For="() => Input.Email" class="text-danger"/>
+                </div>
+                <div>
+                    <label for="password" class="form-label">Password</label>
+                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password"/>
+                    <ValidationMessage For="() => Input.Password" class="text-danger"/>
+                </div>
+                <div>
+                    <label class="form-label">
+                        <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input"/>
+                        Remember me
+                    </label>
+                </div>
+                <div>
+                    <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+                </div>
+                <p>Forgot your password? Please contact me to reset it.</p>
+                @* <div> *@
+                @*     <p> *@
+                @*         <a href="Account/ForgotPassword">Forgot your password?</a> *@
+                @*     </p> *@
+                @*     <p> *@
+                @*         <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Register as a new user</a> *@
+                @*     </p> *@
+                @*     <p> *@
+                @*         <a href="Account/ResendEmailConfirmation">Resend email confirmation</a> *@
+                @*     </p> *@
+                @* </div> *@
+            </EditForm>
+        </Box>
+    </CascadingValue>
 </div>
 
 @code {
     private string? errorMessage;
+
+    private SectionTheme ModalTheme => new(Colour.DarkGrey, Config.Colours.Primary, new BoxStyle(BoxType.Filled, new SectionTheme(Colour.White, Config.Colours.Primary, null)));
 
     [CascadingParameter]
     private HttpContext? HttpContext { get; set; }

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -16,49 +16,47 @@
 
 <PageTitle>Log in</PageTitle>
 
-<div class="row">
-    <div class="container">
-        <section class="login-modal">
-            <h1>Log in</h1>
-            <p>@errorMessage</p>
-            <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
-                <DataAnnotationsValidator />
-                <hr />
-                <ValidationSummary class="text-danger" role="alert" />
-                <div>
-                    <label for="email" class="form-label">Email</label>
-                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                    <ValidationMessage For="() => Input.Email" class="text-danger" />
-                </div>
-                <div>
-                    <label for="password" class="form-label">Password</label>
-                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
-                    <ValidationMessage For="() => Input.Password" class="text-danger" />
-                </div>
-                <div>
-                    <label class="form-label">
-                        <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input" />
-                        Remember me
-                    </label>
-                </div>
-                <div>
-                    <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
-                </div>
-                <p>Forgot your password? Please contact me to reset it.</p>
-                @* <div> *@
-                @*     <p> *@
-                @*         <a href="Account/ForgotPassword">Forgot your password?</a> *@
-                @*     </p> *@
-                @*     <p> *@
-                @*         <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Register as a new user</a> *@
-                @*     </p> *@
-                @*     <p> *@
-                @*         <a href="Account/ResendEmailConfirmation">Resend email confirmation</a> *@
-                @*     </p> *@
-                @* </div> *@
-            </EditForm>
-        </section>
-    </div>
+<div class="container">
+    <section class="login-modal">
+        <h1>Log in</h1>
+        <p>@errorMessage</p>
+        <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
+            <DataAnnotationsValidator />
+            <hr />
+            <ValidationSummary class="text-danger" role="alert" />
+            <div>
+                <label for="email" class="form-label">Email</label>
+                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
+                <ValidationMessage For="() => Input.Email" class="text-danger" />
+            </div>
+            <div>
+                <label for="password" class="form-label">Password</label>
+                <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password" />
+                <ValidationMessage For="() => Input.Password" class="text-danger" />
+            </div>
+            <div>
+                <label class="form-label">
+                    <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input" />
+                    Remember me
+                </label>
+            </div>
+            <div>
+                <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+            </div>
+            <p>Forgot your password? Please contact me to reset it.</p>
+            @* <div> *@
+            @*     <p> *@
+            @*         <a href="Account/ForgotPassword">Forgot your password?</a> *@
+            @*     </p> *@
+            @*     <p> *@
+            @*         <a href="@(NavigationManager.GetUriWithQueryParameters("Account/Register", new Dictionary<string, object?> { ["ReturnUrl"] = ReturnUrl }))">Register as a new user</a> *@
+            @*     </p> *@
+            @*     <p> *@
+            @*         <a href="Account/ResendEmailConfirmation">Resend email confirmation</a> *@
+            @*     </p> *@
+            @* </div> *@
+        </EditForm>
+    </section>
 </div>
 
 @code {

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -65,7 +65,7 @@
     private string? errorMessage;
 
     [CascadingParameter]
-    private HttpContext HttpContext { get; set; } = default!;
+    private HttpContext? HttpContext { get; set; }
 
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = new();
@@ -75,7 +75,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        if (HttpMethods.IsGet(HttpContext.Request.Method))
+        if (HttpContext != null && HttpMethods.IsGet(HttpContext.Request.Method))
         {
             // Clear the existing external cookie to ensure a clean login process
             await HttpContext.SignOutAsync(IdentityConstants.ExternalScheme);

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -33,12 +33,12 @@
                 <hr/>
                 <div class="form-input">
                     <label for="email" class="form-label">Email</label>
-                    <InputText @bind-Value="Input.Email" class="input" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
+                    <InputText @bind-Value="Input.Email" class="login-input" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
                 </div>
                 @* <ValidationMessage For="() => Input.Email" class="validation-message text-danger"/> *@
                 <div class="form-input">
                     <label for="password" class="form-label">Password</label>
-                    <InputText type="password" @bind-Value="Input.Password" class="input" autocomplete="current-password" aria-required="true" placeholder="password" id="password"/>
+                    <InputText type="password" @bind-Value="Input.Password" class="login-input" autocomplete="current-password" aria-required="true" placeholder="password" id="password"/>
                 </div>
                 @* <ValidationMessage For="() => Input.Password" class="validation-message text-danger"/> *@
                 <div class="form-input">

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -53,7 +53,7 @@
                 <div>
                     <button type="submit" style="background: @ModalTheme.Primary">Log in</button>
                 </div>
-                <p>Forgot your password? Please contact me to reset it.</p>
+                <p>Forgot your password? Contact @(WeddingDetails.LoginContactMethod?.Text ?? "one of the organisers").</p>
                 @* <div> *@
                 @*     <p> *@
                 @*         <a href="Account/ForgotPassword">Forgot your password?</a> *@

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -31,22 +31,24 @@
             <EditForm Model="Input" method="post" OnValidSubmit="LoginUser" FormName="login">
                 <DataAnnotationsValidator/>
                 <hr/>
-                <ValidationSummary class="text-danger" role="alert"/>
                 <div class="form-input">
                     <label for="email" class="form-label">Email</label>
                     <InputText @bind-Value="Input.Email" class="input" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
-                    <ValidationMessage For="() => Input.Email" class="text-danger"/>
                 </div>
+                @* <ValidationMessage For="() => Input.Email" class="validation-message text-danger"/> *@
                 <div class="form-input">
                     <label for="password" class="form-label">Password</label>
                     <InputText type="password" @bind-Value="Input.Password" class="input" autocomplete="current-password" aria-required="true" placeholder="password" id="password"/>
-                    <ValidationMessage For="() => Input.Password" class="text-danger"/>
                 </div>
+                @* <ValidationMessage For="() => Input.Password" class="validation-message text-danger"/> *@
                 <div class="form-input">
                     <label class="form-label">
                         <InputCheckbox @bind-Value="Input.RememberMe" class="form-check-input"/>
                         Remember me
                     </label>
+                </div>
+                <div class="validation-container">
+                    <ValidationSummary class="text-danger" role="alert"/>
                 </div>
                 <div>
                     <button type="submit" style="background: @ModalTheme.Primary">Log in</button>

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -32,17 +32,17 @@
                 <DataAnnotationsValidator/>
                 <hr/>
                 <ValidationSummary class="text-danger" role="alert"/>
-                <div>
+                <div class="form-input">
                     <label for="email" class="form-label">Email</label>
                     <InputText @bind-Value="Input.Email" class="input" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
                     <ValidationMessage For="() => Input.Email" class="text-danger"/>
                 </div>
-                <div>
+                <div class="form-input">
                     <label for="password" class="form-label">Password</label>
                     <InputText type="password" @bind-Value="Input.Password" class="input" autocomplete="current-password" aria-required="true" placeholder="password" id="password"/>
                     <ValidationMessage For="() => Input.Password" class="text-danger"/>
                 </div>
-                <div>
+                <div class="form-input">
                     <label class="form-label">
                         <InputCheckbox @bind-Value="Input.RememberMe" class="form-check-input"/>
                         Remember me

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -34,17 +34,17 @@
                 <ValidationSummary class="text-danger" role="alert"/>
                 <div>
                     <label for="email" class="form-label">Email</label>
-                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com"/>
+                    <InputText @bind-Value="Input.Email" class="input" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
                     <ValidationMessage For="() => Input.Email" class="text-danger"/>
                 </div>
                 <div>
                     <label for="password" class="form-label">Password</label>
-                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="current-password" aria-required="true" placeholder="password"/>
+                    <InputText type="password" @bind-Value="Input.Password" class="input" autocomplete="current-password" aria-required="true" placeholder="password" id="password"/>
                     <ValidationMessage For="() => Input.Password" class="text-danger"/>
                 </div>
                 <div>
                     <label class="form-label">
-                        <InputCheckbox @bind-Value="Input.RememberMe" class="darker-border-checkbox form-check-input"/>
+                        <InputCheckbox @bind-Value="Input.RememberMe" class="form-check-input"/>
                         Remember me
                     </label>
                 </div>

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -11,10 +11,13 @@
 @inject ILogger<Login> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
+@inject IWeddingDetails WeddingDetails
 
 @attribute [AllowAnonymous]
 
 <PageTitle>Log in</PageTitle>
+
+<img class="background-image" src="@WeddingDetails.MainImage.Url" alt="@WeddingDetails.MainImage.AltText"/>
 
 <div class="container">
     <section class="login-modal">

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -49,7 +49,7 @@
                     </label>
                 </div>
                 <div>
-                    <button type="submit" class="w-100 btn btn-lg btn-primary">Log in</button>
+                    <button type="submit" style="background: @ModalTheme.Primary">Log in</button>
                 </div>
                 <p>Forgot your password? Please contact me to reset it.</p>
                 @* <div> *@

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -52,10 +52,6 @@ label {
     margin-bottom: 8px;
 }
 
-.text-danger {
-    color: #a94442;
-}
-
 .validation-container {
     padding: 0 10px;
     margin-bottom: 10px;

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -51,3 +51,12 @@ label {
     align-items: center;
     margin-bottom: 8px;
 }
+
+.text-danger {
+    color: #a94442;
+}
+
+.validation-container {
+    padding: 0 10px;
+    margin-bottom: 10px;
+}

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -24,7 +24,7 @@ h1 {
     margin-bottom: 15px;
 }
 
-label, p {
+p {
     margin-bottom: 8px;
 }
 
@@ -39,4 +39,15 @@ button {
 
 button:hover {
     box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}
+
+label {
+    margin-right: 10px;
+}
+
+.form-input {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin-bottom: 8px;
 }

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -19,3 +19,11 @@
     top: 0;
     z-index: -1;
 }
+
+h1 {
+    margin-bottom: 15px;
+}
+
+label, p {
+    margin-bottom: 8px;
+}

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -27,3 +27,16 @@ h1 {
 label, p {
     margin-bottom: 8px;
 }
+
+button {
+    padding: 5px 10px;
+    border-radius: 5px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.075), 0 1px 2px rgba(0, 0, 0, 0.075);
+    transition-property: box-shadow;
+    transition-duration: 0.3s;
+    margin-bottom: 15px;
+}
+
+button:hover {
+    box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2), 0 6px 20px 0 rgba(0, 0, 0, 0.19);
+}

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor.css
@@ -10,3 +10,12 @@
     align-items: center;
     justify-content: center;
 }
+
+.background-image {
+    width: 100vw;
+    height: 100vh;
+    object-fit: cover;
+    position: absolute;
+    top: 0;
+    z-index: -1;
+}

--- a/WeddingWebsite/Models/WeddingDetails/IWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/IWeddingDetails.cs
@@ -22,4 +22,6 @@ public interface IWeddingDetails
     // Helper methods
     public IPerson Groom => NotablePeople.FirstOrDefault(p => p.Role == Role.Groom) ?? new NotablePerson(new Name("Blank", "Groom"), Role.Groom);
     public IPerson Bride => NotablePeople.FirstOrDefault(p => p.Role == Role.Bride) ?? new NotablePerson(new Name("Blank", "Bride"), Role.Bride);
+    public IContactMethod? LoginContactMethod => NotablePeople.Concat(ExtraContacts).Select(p => p.ContactDetails.NotUrgent).FirstOrDefault(p => p.MatchesReason(ContactReason.Website))?.Methods.FirstOrDefault() 
+                                                 ?? NotablePeople.Concat(ExtraContacts).Select(p => p.ContactDetails.Urgent).FirstOrDefault(p => p.MatchesReason(ContactReason.Website))?.Methods.FirstOrDefault();
 }

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -19,7 +19,6 @@ namespace WeddingWebsite.Models.WeddingDetails;
 /// In practice, you won't actually be using this implementation but I'd recommend keeping it around in case you need it.
 /// </summary>
 
-[Authorize]
 public class SampleWeddingDetails : IWeddingDetails
 {
     public SampleWeddingDetails() {

--- a/WeddingWebsite/wwwroot/app.css
+++ b/WeddingWebsite/wwwroot/app.css
@@ -45,10 +45,6 @@ h1:focus {
         content: "An error has occurred."
     }
 
-.darker-border-checkbox.form-check-input {
-    border-color: #929292;
-}
-
 .form-floating > .form-control-plaintext::placeholder, .form-floating > .form-control::placeholder {
     color: var(--bs-secondary-color);
     text-align: end;

--- a/WeddingWebsite/wwwroot/app.css
+++ b/WeddingWebsite/wwwroot/app.css
@@ -2,10 +2,8 @@
     --primary: #36b3d6;
     --bg-primary: #a2eaf6;
     --primary-dark: #102542;
-    --secondary: #f1dc22;
-    --secondary-dark: #e68019;
-    --secondary-background: #fefce7;
-    --tertiary: #275c34;
+    --bg-variant: #fefce7;
+    --secondary: #275c34;
 }
 
 @font-face {

--- a/WeddingWebsite/wwwroot/app.css
+++ b/WeddingWebsite/wwwroot/app.css
@@ -21,18 +21,8 @@ body {
     margin: 0;
 }
 
-a, .btn-link {
+a {
     color: #006bb7;
-}
-
-.btn-primary {
-    color: #fff;
-    background-color: #1b6ec2;
-    border-color: #1861ac;
-}
-
-.btn:focus, .btn:active:focus, .btn-link.nav-link:focus, .form-control:focus, .form-check-input:focus {
-  box-shadow: 0 0 0 0.1rem white, 0 0 0 0.25rem #258cfb;
 }
 
 h1:focus {
@@ -45,10 +35,6 @@ h1:focus {
 
 .invalid {
     outline: 1px solid #e50000;
-}
-
-.validation-message {
-    color: #e50000;
 }
 
 .blazor-error-boundary {

--- a/WeddingWebsite/wwwroot/app.css
+++ b/WeddingWebsite/wwwroot/app.css
@@ -27,6 +27,17 @@ h1:focus {
     outline: none;
 }
 
+.text-danger {
+    color: #e50000;
+}
+
+.login-input {
+    flex: 1;
+    padding: 5px;
+    outline: 1px solid var(--primary);
+    border-radius: 5px;
+}
+
 .valid.modified:not([type=checkbox]) {
     outline: 1px solid #26b050;
 }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
The login page looked awful, even featuring an unhandled error.

Old:
<img width="837" height="464" alt="image" src="https://github.com/user-attachments/assets/ac121cd0-0a60-4907-8320-8a394dee46a7" />

New:
<img width="1192" height="697" alt="image" src="https://github.com/user-attachments/assets/24a06151-43e3-439d-b230-19bb4db4e192" />

## Does this affect the IWeddingDetails interface?
A new computed parameter has been added, but it does not affect existing implementations.

## Are you overriding the default behaviour, or have you added it behind a config option?
Improving behaviour.

## Does any validation logic need adding/updating?
Yes, I have added an info message to flag when a contact is visible publicly.

## Any other comments?
<!-- Please specify anything interesting about your implementation, other solutions you considered etc. -->

## Does this close any issues?
Closes #10