### PR TITLE
Add venue rooms

### DIFF
--- a/WeddingWebsite/Components/WeddingComponents/TimelineItemBox.razor
+++ b/WeddingWebsite/Components/WeddingComponents/TimelineItemBox.razor
@@ -26,7 +26,7 @@
         }
         <div class="event-location">
             <MudIcon Icon="@Icons.Material.Filled.LocationOn"/>
-            <span>@Item.VenueName</span>
+            <span>@Location</span>
         </div>
     </ChildContent>
 </Box>
@@ -34,4 +34,6 @@
 @code {
     [Parameter]
     public required WeddingTimeline.TimelineItem Item { get; set; }
+
+    private string Location => Item.LocationWithinVenue == null ? Item.VenueName : $"{Item.LocationWithinVenue} ({Item.VenueName})";
 }

--- a/WeddingWebsite/Components/WeddingComponents/WeddingTimeline.razor
+++ b/WeddingWebsite/Components/WeddingComponents/WeddingTimeline.razor
@@ -84,6 +84,7 @@
                 ev.Name,
                 "",
                 ev.Venue.Name,
+                ev.LocationWithinVenue,
                 ev.Modals,
                 ev.Icon,
                 ev.Image
@@ -105,6 +106,7 @@
             title : "Transport",
             description : ev.Venue.Directions!.Description,
             venueName : previousVenueName != null ? previousVenueName + " → " + ev.Venue.Name : "Your House → " + ev.Venue.Name,
+            locationWithinVenue: null,
             modals : [new WeddingModal("Travel Directions", ev.Venue.Directions!.Content.Prepend(GenerateTransportTopSection(ev.Venue)))],
             icon: Icons.Material.Filled.DirectionsCar,
             image : ev.Venue.Directions?.CoverImage,
@@ -125,6 +127,7 @@
             "Accommodation",
             AccommodationDetails.Description ?? "If you would like to book accommodation, here are some recommendations",
             GenerateAccommodationShortString(),
+            null,
             [new WeddingModal("Suggested Hotels", GenerateAccommodationDetails(AccommodationDetails))],
             @Icons.Material.Filled.Hotel,
             AccommodationDetails.Image
@@ -164,6 +167,7 @@
         string title,
         string description,
         string venueName,
+        string? locationWithinVenue,
         IEnumerable<WeddingModal> modals,
         string? icon = null,
         WebsiteImage? image = null,
@@ -175,6 +179,7 @@
         public string Title { get; } = title;
         public IEnumerable<WebsiteSection> Description { get; init; } = [new (null, description)];
         public string VenueName { get; } = venueName;
+        public string? LocationWithinVenue { get; } = locationWithinVenue;
         public IEnumerable<WeddingModal> Modals { get; } = modals;
         public string? Icon { get; } = icon;
         public WebsiteImage? Image { get; } = image;

--- a/WeddingWebsite/Models/Event.cs
+++ b/WeddingWebsite/Models/Event.cs
@@ -13,6 +13,7 @@ public record Event(
     TimeOnly? End,
     IEnumerable<WebsiteSection> Description,
     Venue Venue,
+    string? LocationWithinVenue,
     WebsiteImage? Image,
     string? Icon,
     IEnumerable<WeddingModal> Modals
@@ -21,12 +22,12 @@ public record Event(
     /// <summary>
     /// Simple description, no modals
     /// </summary>
-    public Event(string name, TimeOnly start, TimeOnly? end, string description, Venue venue, WebsiteImage? image = null, string? icon = null) 
-        : this(name, start, end, [new WebsiteSection(null, description)], venue, image, icon, new List<WeddingModal>()) {}
+    public Event(string name, TimeOnly start, TimeOnly? end, string description, Venue venue, string? locationWithinVenue = null, WebsiteImage? image = null, string? icon = null) 
+        : this(name, start, end, [new WebsiteSection(null, description)], venue, locationWithinVenue, image, icon, new List<WeddingModal>()) {}
         
     /// <summary>
     /// Simple description, modals
     /// </summary>
-    public Event(string name, TimeOnly start, TimeOnly? end, string description, Venue venue, WebsiteImage? image, string? icon, IEnumerable<WeddingModal> modals) 
-        : this(name, start, end, [new WebsiteSection(null, description)], venue, image, icon, modals) {}
+    public Event(string name, TimeOnly start, TimeOnly? end, string description, Venue venue, string locationWithinVenue, WebsiteImage? image, string? icon, IEnumerable<WeddingModal> modals) 
+        : this(name, start, end, [new WebsiteSection(null, description)], venue, locationWithinVenue, image, icon, modals) {}
 }

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -31,6 +31,7 @@ public class SampleWeddingDetails : IWeddingDetails
                 TimeOnly.Parse("13:00"), 
                 "The church service in which we get married.",
                 CeremonyVenue, 
+                null,
                 new WebsiteImage("https://www.wedgewoodweddings.com/hubfs/3.0%20Feature%20Images%201000%20x%20500%20px/Blog/Lets%20Talk%20About%20Beach%20Weddings.png", "A wedding ceremony on a beach")
             ),
             new (
@@ -39,6 +40,7 @@ public class SampleWeddingDetails : IWeddingDetails
                 TimeOnly.Parse("15:00"), 
                 "Join us for drinks and canapés in the garden.", 
                 ReceptionVenue, 
+                "The Courtyard",
                 new WebsiteImage("https://www.confetti.co.uk/blog/wp-content/uploads/2013/04/alitrystan39.jpg", "Some bottles of champagne surrounded by lots of empty glasses")
                 ),
             new (
@@ -47,6 +49,7 @@ public class SampleWeddingDetails : IWeddingDetails
                 TimeOnly.Parse("18:00"),
                 "A sit-down meal with speeches and toasts.", 
                 ReceptionVenue, 
+                "The Barn",
                 new WebsiteImage("https://wpmedia.bridebook.com/wp-content/uploads/2024/12/tTqnnv01-858154ee-97ae-4e73-ab3c-ccc28bdeb395.jpg", "A long table with guests eating food"), 
                 null, 
                 [
@@ -63,6 +66,7 @@ public class SampleWeddingDetails : IWeddingDetails
                 TimeOnly.Parse("23:00"),
                 "An evening of dancing and celebration.", 
                 ReceptionVenue, 
+                "The Barn",
                 new WebsiteImage("https://images.squarespace-cdn.com/content/v1/5f5afb7d868b466f42d4b4fb/77e1c31d-3913-4202-bd13-e5ce142a1f7f/wedding-dance-floor-playlist-20.png", "Guests dancing at a wedding")
             )
         };


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds the ability to specify a specific room for an event to happen in, not just the generic venue.

<img width="1022" height="668" alt="image" src="https://github.com/user-attachments/assets/d3700161-0f5c-45a8-a7b6-e3002884a1ca" />

## Does this affect the IWeddingDetails interface?
Yes, this is a breaking change. Users will need to explicitly specify null if they have listed parameters past the venue.

## Are you overriding the default behaviour, or have you added it behind a config option?
Only changes behaviour if optional location is given.

## Does any validation logic need adding/updating?
No.

## Any other comments?
No.

## Does this close any issues?
No.