### PR TITLE
Venue showcase

### DIFF
--- a/WeddingWebsite/Components/Containers/Box.razor
+++ b/WeddingWebsite/Components/Containers/Box.razor
@@ -3,9 +3,9 @@
 @if (Theme != null && Theme.BoxStyle != null) {
     <CascadingValue Value="Theme.BoxStyle.InnerTheme">
         @if (Theme.BoxStyle.Type == BoxType.OutlinedSquare) {
-            <OutlinedBox ChildContent="@ChildContent" TopContent="@TopContent" Horizontal="Horizontal"/>
+            <OutlinedBox ChildContent="@ChildContent" TopContent="@TopContent" Horizontal="Horizontal" CustomCss="@CustomCss"/>
         } else if (Theme.BoxStyle.Type == BoxType.FilledRounded) {
-            <RoundedCornerBox ChildContent="@ChildContent" TopContent="@TopContent" Horizontal="Horizontal"/>
+            <RoundedCornerBox ChildContent="@ChildContent" TopContent="@TopContent" Horizontal="Horizontal" CustomCss="@CustomCss"/>
         } else {
             <p>Unsupported box type: @Theme.BoxStyle.Type</p>
         }
@@ -26,4 +26,7 @@
     
     [Parameter]
     public bool Horizontal { get; set; }
+    
+    [Parameter] 
+    public string CustomCss { get; set; } = "";
 }

--- a/WeddingWebsite/Components/Containers/OutlinedBox.razor
+++ b/WeddingWebsite/Components/Containers/OutlinedBox.razor
@@ -1,7 +1,7 @@
 ﻿@using WeddingWebsite.Models.Theme
 @using WeddingWebsite.Models.WebsiteConfig
 
-<div class="outlined-box @CssHorizontal" style="@Background.GetBackgroundCss(); color: @Background.GetTextColour()">
+<div class="outlined-box @CssHorizontal" style="@Background.GetBackgroundCss(); color: @Background.GetTextColour();@CustomCss">
     <div class="top-content">
         @TopContent
     </div>
@@ -22,6 +22,9 @@
     
     [Parameter]
     public bool Horizontal { get; set; }
+    
+    [Parameter] 
+    public string CustomCss { get; set; } = "";
     
     [CascadingParameter]
     public SectionTheme? Theme { get; set; }

--- a/WeddingWebsite/Components/Containers/OutlinedBox.razor.css
+++ b/WeddingWebsite/Components/Containers/OutlinedBox.razor.css
@@ -3,6 +3,13 @@
     border-width: 2px;
     border-style: solid;
     border-radius: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.top-content {
+    flex: 1;
+    min-height: 0;
 }
 
 .outlined-box-inner {
@@ -11,7 +18,7 @@
 
 @media only screen and (min-width: 600px) {
     .horizontal {
-        display: flex;
+        flex-direction: row;
     }
 
     .horizontal .top-content {

--- a/WeddingWebsite/Components/Containers/RoundedCornerBox.razor
+++ b/WeddingWebsite/Components/Containers/RoundedCornerBox.razor
@@ -3,7 +3,7 @@
 
 @inject IWebsiteConfig Config
 
-<div class="rounded-corner-box @CssShadow @CssHorizontal" style="@Background.GetBackgroundCss(); color: @Background.GetTextColour()">
+<div class="rounded-corner-box @CssShadow @CssHorizontal" style="@Background.GetBackgroundCss(); color: @Background.GetTextColour();@CustomCss">
     <div class="top-content">
         @TopContent
     </div>
@@ -21,6 +21,9 @@
     
     [Parameter]
     public bool Horizontal { get; set; }
+
+    [Parameter] 
+    public string CustomCss { get; set; } = "";
     
     [CascadingParameter]
     public SectionTheme? Theme { get; set; }

--- a/WeddingWebsite/Components/Containers/RoundedCornerBox.razor.css
+++ b/WeddingWebsite/Components/Containers/RoundedCornerBox.razor.css
@@ -2,6 +2,13 @@
     color: var(--primary-dark);
     border-radius: 25px;
     overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.top-content {
+    flex: 1;
+    min-height: 0;
 }
 
 .rounded-corner-box-inner {
@@ -14,7 +21,7 @@
 
 @media only screen and (min-width: 600px) {
     .horizontal {
-        display: flex;
+        flex-direction: row;
     }
 
     .horizontal .top-content {

--- a/WeddingWebsite/Components/Docs.cs
+++ b/WeddingWebsite/Components/Docs.cs
@@ -6,9 +6,12 @@ namespace WeddingWebsite.Components.Containers
     /// <summary>
     /// A box which changes type depending on the cascading SectionTheme.
     /// Type is either <see cref="OutlinedBox"/> or <see cref="RoundedCornerBox"/>.
+    /// If the box has a specific height (with custom css), then the top content automatically shrinks when needed.
     /// </summary>
     /// <param name="ChildContent">The content to be placed within the default padding.</param>
     /// <param name="TopContent">(Optional) The content to be placed above the normal content, with no padding.</param>
+    /// <param name="Horizontal">(Optional) Display horizontal, when wide enough. Defaults to false.</param>
+    /// <param name="CustomCss">(Optional) Custom CSS styles.</param>
     partial class Box {}
     
     /// <summary>

--- a/WeddingWebsite/Components/Pages/Home.razor
+++ b/WeddingWebsite/Components/Pages/Home.razor
@@ -48,6 +48,7 @@
         @if (sect is Section.MeetWeddingParty party) { <MeetWeddingPartySection DisplayMode="party.DisplayMode" RolesLeft="party.RolesLeft" RolesRight="party.RolesRight"/> }
         @if (sect is Section.Contact contact) { <ContactSection ReasonsToShow="contact.ReasonsToShow" ShowUrgencyOption="contact.ShowUrgencyOption"/> }
         @if (sect is Section.DressCode dress) { <DressCodeSection WrapInBox="dress.WrapInBox" ShowContact="dress.ShowContact"/> }
+        @if (sect is Section.VenueShowcase) { <VenueShowcaseSection/> }
     </CascadingValue>
 }
 

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcase.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcase.razor
@@ -1,0 +1,22 @@
+﻿@using WeddingWebsite.Components.Containers
+@using WeddingWebsite.Models.Venues
+
+@if (Venues.Count >= 2)
+{
+    <SideBySide HalfSpacing="10px">
+        <LeftContent>
+            <VenueShowcaseVenue Venue="@Venues[0]"/>
+        </LeftContent>
+        <RightContent>
+            <VenueShowcaseVenue Venue="@Venues[1]"/>
+        </RightContent>
+    </SideBySide>
+} else if (Venues.Count == 1)
+{
+    <VenueShowcaseVenue Venue="@Venues[0]"/>
+}
+
+@code {
+    [Parameter]
+    public required IList<Venue> Venues { get; set; }
+}

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -1,0 +1,22 @@
+﻿@using WeddingWebsite.Components.Containers
+@using WeddingWebsite.Components.Elements
+@using WeddingWebsite.Models.Venues
+
+<Box>
+    <TopContent>
+        <WebsiteElement Element="Venue.Media" MaxHeight="300px" Cover="true"></WebsiteElement>
+    </TopContent>
+    <ChildContent>
+        <h3>@Venue.Name</h3>
+        <p>@Venue.Description</p>
+        <div class="address">
+            <MudIcon Icon="@Icons.Material.Filled.LocationOn"/>
+            <span>@Venue.Address</span>
+        </div>
+    </ChildContent>
+</Box>
+
+@code {
+    [Parameter]
+    public required Venue Venue { get; set; }
+}

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -2,6 +2,7 @@
 @using WeddingWebsite.Components.Elements
 @using WeddingWebsite.Models.Venues
 @using WeddingWebsite.Components.Dialogs
+@using WeddingWebsite.Models.WebsiteElement
 
 <Box>
     <TopContent>
@@ -14,6 +15,10 @@
             <MudIcon Icon="@Icons.Material.Filled.LocationOn"/>
             <span>@Venue.Address</span>
         </div>
+        @if (TravelDirectionsModal != null)
+        {
+            <ModalButton Modal="@TravelDirectionsModal"/>
+        }
         @foreach (var modal in Venue.Modals) {
             <ModalButton Modal="@modal"/>
         }
@@ -23,4 +28,7 @@
 @code {
     [Parameter]
     public required Venue Venue { get; set; }
+
+    private WeddingModal? TravelDirectionsModal => Venue.Directions == null ? null 
+        : new WeddingModal("Travel Directions", Venue.Directions!.Content.Prepend(new WebsiteSection(new WebsiteGoogleMapsEmbed(Venue.Location))));
 }

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -22,6 +22,7 @@
         @foreach (var modal in Venue.Modals) {
             <ModalButton Modal="@modal"/>
         }
+        <div style="margin-bottom: 5px"></div>
     </ChildContent>
 </Box>
 

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -1,6 +1,7 @@
 ﻿@using WeddingWebsite.Components.Containers
 @using WeddingWebsite.Components.Elements
 @using WeddingWebsite.Models.Venues
+@using WeddingWebsite.Components.Dialogs
 
 <Box>
     <TopContent>
@@ -13,6 +14,9 @@
             <MudIcon Icon="@Icons.Material.Filled.LocationOn"/>
             <span>@Venue.Address</span>
         </div>
+        @foreach (var modal in Venue.Modals) {
+            <ModalButton Modal="@modal"/>
+        }
     </ChildContent>
 </Box>
 

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -25,6 +25,7 @@
         <div style="margin-bottom: 5px"></div>
     </ChildContent>
 </Box>
+<div style="margin-bottom: 20px"></div>
 
 @code {
     [Parameter]

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor
@@ -4,9 +4,9 @@
 @using WeddingWebsite.Components.Dialogs
 @using WeddingWebsite.Models.WebsiteElement
 
-<Box>
+<Box CustomCss="height: 400px;">
     <TopContent>
-        <WebsiteElement Element="Venue.Media" MaxHeight="300px" Cover="true"></WebsiteElement>
+        <WebsiteElement Element="Venue.Media" Cover="true"></WebsiteElement>
     </TopContent>
     <ChildContent>
         <h3>@Venue.Name</h3>

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
@@ -1,4 +1,10 @@
-﻿.address {
+﻿h3 {
+    font-size: 24px;
+    margin-bottom: 5px;
+    margin-top: 5px;
+}
+
+.address {
     display: flex;
     margin-bottom: 10px;
 }

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
@@ -1,0 +1,7 @@
+﻿.address {
+    display: flex;
+}
+
+p {
+    margin-bottom: 10px;
+}

--- a/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
+++ b/WeddingWebsite/Components/WeddingComponents/VenueShowcaseVenue.razor.css
@@ -1,5 +1,6 @@
 ﻿.address {
     display: flex;
+    margin-bottom: 10px;
 }
 
 p {

--- a/WeddingWebsite/Components/WeddingSections/VenueShowcaseSection.razor
+++ b/WeddingWebsite/Components/WeddingSections/VenueShowcaseSection.razor
@@ -1,0 +1,13 @@
+﻿@using WeddingWebsite.Components.Sections
+@using WeddingWebsite.Components.WeddingComponents
+@using WeddingWebsite.Models.WeddingDetails
+
+@inject IWeddingDetails WeddingDetails
+
+<Section>
+    <SectionHeading>Venue Showcase</SectionHeading>
+    <VenueShowcase Venues="WeddingDetails.Events.Select(ev => ev.Venue).DistinctBy(v => v.Name).ToList()"/>
+</Section>
+
+@code {
+}

--- a/WeddingWebsite/Models/Venues/Venue.cs
+++ b/WeddingWebsite/Models/Venues/Venue.cs
@@ -1,6 +1,8 @@
-﻿namespace WeddingWebsite.Models.Venues;
+﻿using WeddingWebsite.Models.WebsiteElement;
+
+namespace WeddingWebsite.Models.Venues;
 
 /// <summary>
 /// A venue that stuff happens in.
 /// </summary>
-public record Venue (string Name, Location Location, string Address, TravelDirections? Directions = null);
+public record Venue (string Name, Location Location, string Address, TravelDirections? Directions = null, IWebsiteElement? Media = null);

--- a/WeddingWebsite/Models/Venues/Venue.cs
+++ b/WeddingWebsite/Models/Venues/Venue.cs
@@ -5,4 +5,10 @@ namespace WeddingWebsite.Models.Venues;
 /// <summary>
 /// A venue that stuff happens in.
 /// </summary>
-public record Venue (string Name, Location Location, string Address, TravelDirections? Directions = null, IWebsiteElement? Media = null);
+/// <param name="Name">Needs to uniquely identify the venue</param>
+/// <param name="Location">Used in travel directions modal.</param>
+/// <param name="Address">Used in timeline (travel directions modal only) and venue showcase.</param>
+/// <param name="Directions">Used in timeline and venue showcase.</param>
+/// <param name="Description">Used in venue showcase only.</param>
+/// <param name="Media">Used in venue showcase only.</param>
+public record Venue(string Name, Location Location, string Address, TravelDirections? Directions = null, string? Description = null, IWebsiteElement? Media = null);

--- a/WeddingWebsite/Models/Venues/Venue.cs
+++ b/WeddingWebsite/Models/Venues/Venue.cs
@@ -11,4 +11,12 @@ namespace WeddingWebsite.Models.Venues;
 /// <param name="Directions">Used in timeline and venue showcase.</param>
 /// <param name="Description">Used in venue showcase only.</param>
 /// <param name="Media">Used in venue showcase only.</param>
-public record Venue(string Name, Location Location, string Address, TravelDirections? Directions = null, string? Description = null, IWebsiteElement? Media = null);
+/// <param name="Modals">Used in venue showcase only.</param>
+public record Venue(string Name, Location Location, string Address, TravelDirections? Directions, string? Description, IWebsiteElement? Media, IEnumerable<WeddingModal> Modals)
+{
+    /// <summary>
+    /// Default with no modals.
+    /// </summary>
+    public Venue(string Name, Location Location, string Address, TravelDirections? Directions = null, string? Description = null, IWebsiteElement? Media = null) 
+        : this(Name, Location, Address, Directions, Description, Media, []) {}
+}

--- a/WeddingWebsite/Models/WebsiteConfig/Section.cs
+++ b/WeddingWebsite/Models/WebsiteConfig/Section.cs
@@ -62,4 +62,9 @@ public abstract record Section
         bool WrapInBox = true,
         bool ShowContact = true
     ) : Section(Theme);
+
+    /// <summary>
+    /// A showcase of the venues. All this information is already in the timeline.
+    /// </summary>
+    public sealed record VenueShowcase(SectionTheme? Theme = null) : Section(Theme);
 }

--- a/WeddingWebsite/Models/WebsiteConfig/WebsiteConfig.cs
+++ b/WeddingWebsite/Models/WebsiteConfig/WebsiteConfig.cs
@@ -22,8 +22,10 @@ public class WebsiteConfig : IWebsiteConfig
         var salmon = new Colour(236, 129, 108, Colour.VeryDarkGrey);
         var lightGreen = new Colour(112, 229, 130);
         var darkGreen = new Colour(50, 150, 50);
+        var darkYellow = new Colour(246, 190, 0);
+        var darkPurple = new Colour(137, 108, 166);
 
-        var filledBox = new BoxStyle(BoxType.FilledRounded, new SectionTheme(Colours.PrimaryBackground, darkGreen, null));
+        var filledBox = new BoxStyle(BoxType.FilledRounded, new SectionTheme(Colours.PrimaryBackground, darkPurple, null));
         var outlinedBox = new BoxStyle(BoxType.OutlinedSquare, new SectionTheme(Colour.White, Colours.Primary, null));
         
         var bricks = new BackgroundImage("/bg/bricks.jpg", false, "50%", new Colour(255, 255, 255, 150), 0.3, true);
@@ -32,6 +34,7 @@ public class WebsiteConfig : IWebsiteConfig
             new Section.Timeline(new SectionTheme(bricks, Colours.Primary, outlinedBox), true),
             new Section.DressCode(new SectionTheme(purple, Colours.Primary, filledBox)),
             new Section.MeetWeddingParty(new SectionTheme(bricks, Colours.Primary, outlinedBox)),
+            new Section.VenueShowcase(new SectionTheme(purple, Colours.Primary, filledBox)),
             new Section.Contact(new SectionTheme(Colours.Secondary, Colours.Primary, filledBox))
         ];
         

--- a/WeddingWebsite/Models/WebsiteConfig/WebsiteConfig.cs
+++ b/WeddingWebsite/Models/WebsiteConfig/WebsiteConfig.cs
@@ -18,8 +18,12 @@ public class WebsiteConfig : IWebsiteConfig
         var surfaceVariant = new Colour(254, 252, 231);
         
         var purple = new Colour("#DCCCEC");
+        var coral = new Colour(239, 111, 108);
+        var salmon = new Colour(236, 129, 108, Colour.VeryDarkGrey);
+        var lightGreen = new Colour(112, 229, 130);
+        var darkGreen = new Colour(50, 150, 50);
 
-        var filledBox = new BoxStyle(BoxType.FilledRounded, new SectionTheme(Colours.PrimaryBackground, Colours.Primary, null));
+        var filledBox = new BoxStyle(BoxType.FilledRounded, new SectionTheme(Colours.PrimaryBackground, darkGreen, null));
         var outlinedBox = new BoxStyle(BoxType.OutlinedSquare, new SectionTheme(Colour.White, Colours.Primary, null));
         
         var bricks = new BackgroundImage("/bg/bricks.jpg", false, "50%", new Colour(255, 255, 255, 150), 0.3, true);
@@ -30,10 +34,6 @@ public class WebsiteConfig : IWebsiteConfig
             new Section.MeetWeddingParty(new SectionTheme(bricks, Colours.Primary, outlinedBox)),
             new Section.Contact(new SectionTheme(Colours.Secondary, Colours.Primary, filledBox))
         ];
-
-        var coral = new Colour(239, 111, 108);
-        var salmon = new Colour(236, 129, 108, Colour.VeryDarkGrey);
-        var lightGreen = new Colour(112, 229, 130);
         
         TopButtons = new TopButtonsConfig(
             [

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -211,6 +211,7 @@ public class SampleWeddingDetails : IWeddingDetails
             null,
             20
         ),
+        "A beautiful picturesque garden for a wonderful party with the animals!",
         new WebsiteImage("https://media.swncdn.com/via/9367-flickr-faunggs-photos.jpg", "The Garden of Eden filled with animals and Adam and Eve")
     );
     
@@ -227,6 +228,7 @@ public class SampleWeddingDetails : IWeddingDetails
             null,
             new WebsiteImage("https://www.instant-quote.co/images/cars/large/o_1ikkmciu01pgc1uko1lh71o60j0p1c.jpeg", "A wedding car")
         ),
+        "A very large church, also for all the animals, I guess.",
         new WebsiteImage("https://upload.wikimedia.org/wikipedia/commons/a/a6/St_Mary%27s_Southampton.jpg", "St Mary's Church, Southampton")
     );
     

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -210,7 +210,8 @@ public class SampleWeddingDetails : IWeddingDetails
             ],
             null,
             20
-        )
+        ),
+        new WebsiteImage("https://media.swncdn.com/via/9367-flickr-faunggs-photos.jpg", "The Garden of Eden filled with animals and Adam and Eve")
     );
     
     public Venue CeremonyVenue { get; } = new(
@@ -225,7 +226,8 @@ public class SampleWeddingDetails : IWeddingDetails
             null,
             null,
             new WebsiteImage("https://www.instant-quote.co/images/cars/large/o_1ikkmciu01pgc1uko1lh71o60j0p1c.jpeg", "A wedding car")
-        )
+        ),
+        new WebsiteImage("https://upload.wikimedia.org/wikipedia/commons/a/a6/St_Mary%27s_Southampton.jpg", "St Mary's Church, Southampton")
     );
     
     public IEnumerable<Event> Events { get; } 

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -212,7 +212,10 @@ public class SampleWeddingDetails : IWeddingDetails
             20
         ),
         "A beautiful picturesque garden for a wonderful party with the animals!",
-        new WebsiteImage("https://media.swncdn.com/via/9367-flickr-faunggs-photos.jpg", "The Garden of Eden filled with animals and Adam and Eve")
+        new WebsiteImage("https://media.swncdn.com/via/9367-flickr-faunggs-photos.jpg", "The Garden of Eden filled with animals and Adam and Eve"),
+        [
+            new WeddingModal("View Map", "Map not yet available.")
+        ]
     );
     
     public Venue CeremonyVenue { get; } = new(
@@ -229,7 +232,10 @@ public class SampleWeddingDetails : IWeddingDetails
             new WebsiteImage("https://www.instant-quote.co/images/cars/large/o_1ikkmciu01pgc1uko1lh71o60j0p1c.jpeg", "A wedding car")
         ),
         "A very large church, also for all the animals, I guess.",
-        new WebsiteImage("https://upload.wikimedia.org/wikipedia/commons/a/a6/St_Mary%27s_Southampton.jpg", "St Mary's Church, Southampton")
+        new WebsiteImage("https://upload.wikimedia.org/wikipedia/commons/a/a6/St_Mary%27s_Southampton.jpg", "St Mary's Church, Southampton"),
+        [
+            new WeddingModal("Fire Safety Information", "Don't burn the place down, please.")
+        ]
     );
     
     public IEnumerable<Event> Events { get; } 


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds a new section to show off some stuff about the venue. While this information is already present in the timeline, it's a nice to have if you want to have a bit more info about the venue(s).

One venue:
<img width="1171" height="607" alt="image" src="https://github.com/user-attachments/assets/4c2b6ed4-7830-41c4-8540-7a7cc11f4603" />

Two venues:
<img width="1095" height="601" alt="image" src="https://github.com/user-attachments/assets/3bef100d-2eea-45b4-bd5e-14944815da7e" />

More than two venues are not supported.

## Does this affect the IWeddingDetails interface?
New optional parameters have been added to Venue.

## Are you overriding the default behaviour, or have you added it behind a config option?
This section will be visible by default, but is easily disabled. All sections will feature in the default template so that users can see what they're like.

## Does any validation logic need adding/updating?
Added:
- no two venues with same name
- not more than two venues (if venue showcase section is present)

## Any other comments?
More than two venues is not that hard to implement later, but is probably not needed.

## Does this close any issues?
Closes #16
