### PR TITLE
Allow registering new users

### DIFF
--- a/WeddingWebsite/Components/App.razor
+++ b/WeddingWebsite/Components/App.razor
@@ -17,8 +17,17 @@
 </head>
 
 <body>
-<Routes @rendermode="InteractiveServer  "/>
+<Routes @rendermode="RenderModeForPage"/>
 <script src="_framework/blazor.web.js"></script>
 </body>
 
 </html>
+
+@code {
+    [CascadingParameter]
+    private HttpContext HttpContext { get; set; } = default!;
+
+    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+        ? null
+        : InteractiveServer;
+}

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -100,7 +100,7 @@
         var result = await SignInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
         if (result.Succeeded)
         {
-            Logger.LogInformation("User logged in.");
+            Logger.LogInformation($"User logged in: {Input.Email}.");
             RedirectManager.RedirectTo(ReturnUrl);
         }
         else if (result.RequiresTwoFactor)

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -76,7 +76,7 @@
     private SectionTheme ModalTheme => new(Colour.DarkGrey, Config.Colours.Primary, new BoxStyle(BoxType.FilledRounded, new SectionTheme(Colour.White, Config.Colours.Primary, null)));
 
     [CascadingParameter]
-    private HttpContext? HttpContext { get; set; }
+    public required HttpContext HttpContext { get; set; }
 
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = new();

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor
@@ -8,6 +8,7 @@
 @using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Core
 @using WeddingWebsite.Data
+@using WeddingWebsite.Services
 
 @inject UserManager<Account> UserManager
 @inject IUserStore<Account> UserStore
@@ -15,6 +16,7 @@
 @inject ILogger<Register> Logger
 @inject NavigationManager NavigationManager
 @inject IdentityRedirectManager RedirectManager
+@inject IAdminService AdminService
 
 @attribute [Authorize ( Roles = "Admin") ]
 
@@ -35,7 +37,7 @@
                 <ValidationSummary class="text-danger" role="alert" />
                 <div class="form-floating">
                     <label for="email">Email</label>
-                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email" />
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="john@smith.com" id="email" />
                     <ValidationMessage For="() => Input.Email" class="text-danger" />
                 </div>
                 <div class="form-floating">
@@ -49,7 +51,20 @@
                     <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
                 </div>
                 <h2>Guests</h2>
-                <p>Quickly add some guests now, or add them later. Guests should be added before sending out the credentials.</p>
+                <p>Quickly add some guests now, or add them later. Please enter first name and surname, or leave them blank.</p>
+                <div class="form-floating">
+                    <label for="guest1">Guest 1 (optional)</label>
+                    <InputText @bind-Value="Input.Guest1" class="form-control" placeholder="John Smith" id="guest1" />
+                </div>
+                <div class="form-floating">
+                    <label for="guest2">Guest 2 (optional)</label>
+                    <InputText @bind-Value="Input.Guest2" class="form-control" placeholder="Jane Smith" id="guest2" />
+                </div>
+                <div class="form-floating">
+                    <label for="guest3">Guest 3 (optional)</label>
+                    <InputText @bind-Value="Input.Guest3" class="form-control" placeholder="Johnny Smith" id="guest3" />
+                </div>
+                <p>If you want to add more than three guests, please add three now and the rest later.</p>
                 <button type="submit">Register</button>
             </EditForm>
         </div>
@@ -77,6 +92,15 @@
         if (!result.Succeeded)
         {
             identityErrors = result.Errors;
+        }
+        
+        foreach (var guestName in new[] { Input.Guest1, Input.Guest2, Input.Guest3 })
+        {
+            if (string.IsNullOrWhiteSpace(guestName)) continue;
+            var names = guestName.Split(' ', 2);
+            var firstName = names[0];
+            var lastName = names.Length > 1 ? names[1] : "";
+            AdminService.AddGuestToAccount(user.Id, firstName, lastName);
         }
     }
 
@@ -119,5 +143,9 @@
         [Display(Name = "Confirm password")]
         [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
         public string ConfirmPassword { get; set; } = "";
+
+        [Display(Name = "Guest 1 (optional)")] public string Guest1 { get; set; } = "";
+        [Display(Name = "Guest 2 (optional)")] public string Guest2 { get; set; } = "";
+        [Display(Name = "Guest 3 (optional)")] public string Guest3 { get; set; } = "";
     }
 }

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor
@@ -110,6 +110,8 @@
             var lastName = names.Length > 1 ? names[1] : "";
             AdminService.AddGuestToAccount(user.Id, firstName, lastName);
         }
+        
+        RedirectManager.RedirectToCurrentPage();
     }
 
     private Account CreateUser()

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor
@@ -64,7 +64,15 @@
                     <label for="guest3">Guest 3 (optional)</label>
                     <InputText @bind-Value="Input.Guest3" class="form-control" placeholder="Johnny Smith" id="guest3" />
                 </div>
-                <p>If you want to add more than three guests, please add three now and the rest later.</p>
+                <div class="form-floating">
+                    <label for="guest4">Guest 4 (optional)</label>
+                    <InputText @bind-Value="Input.Guest4" class="form-control" placeholder="Janet Smith" id="guest4" />
+                </div>
+                <div class="form-floating">
+                    <label for="guest5">Guest 5 (optional)</label>
+                    <InputText @bind-Value="Input.Guest5" class="form-control" placeholder="Jacob Smith" id="guest5" />
+                </div>
+                <p>You can always add more later.</p>
                 <button type="submit">Register</button>
             </EditForm>
         </div>
@@ -94,7 +102,7 @@
             identityErrors = result.Errors;
         }
         
-        foreach (var guestName in new[] { Input.Guest1, Input.Guest2, Input.Guest3 })
+        foreach (var guestName in new[] { Input.Guest1, Input.Guest2, Input.Guest3, Input.Guest4, Input.Guest5 })
         {
             if (string.IsNullOrWhiteSpace(guestName)) continue;
             var names = guestName.Split(' ', 2);
@@ -147,5 +155,7 @@
         [Display(Name = "Guest 1 (optional)")] public string Guest1 { get; set; } = "";
         [Display(Name = "Guest 2 (optional)")] public string Guest2 { get; set; } = "";
         [Display(Name = "Guest 3 (optional)")] public string Guest3 { get; set; } = "";
+        [Display(Name = "Guest 4 (optional)")] public string Guest4 { get; set; } = "";
+        [Display(Name = "Guest 5 (optional)")] public string Guest5 { get; set; } = "";
     }
 }

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Identity
 @using Microsoft.AspNetCore.WebUtilities
+@using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Core
 @using WeddingWebsite.Data
 
@@ -19,35 +20,42 @@
 
 <PageTitle>Register</PageTitle>
 
-<h1>Register</h1>
-
-<div class="row">
-    <div class="col-md-4">
-        <p>@Message</p>
-        <EditForm Model="Input" asp-route-returnUrl="@ReturnUrl" method="post" OnValidSubmit="RegisterUser" FormName="register">
-            <DataAnnotationsValidator />
-            <h2>Create a new account.</h2>
-            <hr />
-            <ValidationSummary class="text-danger" role="alert" />
-            <div class="form-floating mb-3">
-                <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" />
-                <label for="email">Email</label>
-                <ValidationMessage For="() => Input.Email" class="text-danger" />
-            </div>
-            <div class="form-floating mb-3">
-                <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label for="password">Password</label>
-                <ValidationMessage For="() => Input.Password" class="text-danger" />
-            </div>
-            <div class="form-floating mb-3">
-                <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" />
-                <label for="confirm-password">Confirm Password</label>
-                <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
-            </div>
-            <button type="submit" class="w-100 btn btn-lg btn-primary">Register</button>
-        </EditForm>
+<Section>
+    
+    <h1>Create Account</h1>
+    <p>Create a new account for someone else.</p>
+    
+    <div class="row">
+        <div class="col-md-4">
+            <p>@Message</p>
+            <EditForm Model="Input" method="post" OnValidSubmit="RegisterUser" FormName="register">
+                <DataAnnotationsValidator />
+                <h2>Account Details</h2>
+                <hr />
+                <ValidationSummary class="text-danger" role="alert" />
+                <div class="form-floating">
+                    <label for="email">Email</label>
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email" />
+                    <ValidationMessage For="() => Input.Email" class="text-danger" />
+                </div>
+                <div class="form-floating">
+                    <label for="password">Password</label>
+                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" id="password" />
+                    <ValidationMessage For="() => Input.Password" class="text-danger" />
+                </div>
+                <div class="form-floating">
+                    <label for="confirm-password">Confirm Password</label>
+                    <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" id="confirm-password" />
+                    <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
+                </div>
+                <h2>Guests</h2>
+                <p>Quickly add some guests now, or add them later. Guests should be added before sending out the credentials.</p>
+                <button type="submit">Register</button>
+            </EditForm>
+        </div>
     </div>
-</div>
+
+</Section>
 
 @code {
     private IEnumerable<IdentityError>? identityErrors;
@@ -55,15 +63,10 @@
     [SupplyParameterFromForm]
     private InputModel Input { get; set; } = new();
 
-    [SupplyParameterFromQuery]
-    private string? ReturnUrl { get; set; }
-
     private string? Message => identityErrors is null ? null : $"Error: {string.Join(", ", identityErrors.Select(error => error.Description))}";
 
     public async Task RegisterUser(EditContext editContext)
     {
-        Logger.LogInformation("Registering a new user.");
-    
         var user = CreateUser();
 
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
@@ -74,17 +77,7 @@
         if (!result.Succeeded)
         {
             identityErrors = result.Errors;
-            return;
         }
-
-        Logger.LogInformation("User created a new account with password.");
-
-        var userId = await UserManager.GetUserIdAsync(user);
-        var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
-        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
-
-        // await SignInManager.SignInAsync(user, isPersistent: false);
-        // RedirectManager.RedirectTo(ReturnUrl);
     }
 
     private Account CreateUser()

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor.css
@@ -1,0 +1,21 @@
+h1 {
+    margin-top: 100px;
+    margin-bottom: 10px;
+}
+
+p {
+    margin-bottom: 10px;
+}
+
+button {
+    background: var(--primary);
+    box-shadow: 1px 2px 6px rgba(0,0,0,0.2);
+    font-size: 18px;
+    border-radius: 5px;
+    padding: 5px 10px;
+    margin-top: 20px;
+}
+
+button:hover {
+    box-shadow: 1px 2px 12px rgba(0,0,0,0.4);
+}

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor.css
@@ -3,7 +3,7 @@ h1 {
     margin-bottom: 10px;
 }
 
-p {
+p, h2, .form-floating {
     margin-bottom: 10px;
 }
 

--- a/WeddingWebsite/Components/Pages/Auth/Setup.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Setup.razor
@@ -1,0 +1,180 @@
+﻿@page "/Account/Setup"
+
+@using System.ComponentModel.DataAnnotations
+@using System.Text
+@using Microsoft.AspNetCore.Identity
+@using Microsoft.AspNetCore.Identity.EntityFrameworkCore
+@using Microsoft.AspNetCore.WebUtilities
+@using Microsoft.EntityFrameworkCore
+@using WeddingWebsite.Components.Sections
+@using WeddingWebsite.Core
+@using WeddingWebsite.Data
+
+@inject UserManager<Account> UserManager
+@inject IUserStore<Account> UserStore
+@inject ILogger<Register> Logger
+@inject SignInManager<Account> SignInManager
+@inject IdentityRedirectManager RedirectManager
+@inject RoleManager<IdentityRole> RoleManager
+
+@attribute [AllowAnonymous]
+
+<Section>
+    
+    <h1>Account Setup</h1>
+
+    <p>This page is used to create an admin user to get you started. Once there exists a user in the database, this page will not work. If it will give you any extra peace of mind, you can delete this page entirely after adding an admin user.</p>
+
+    <p>This is different from the normal registration page which permits admin users only, and should be used in future.</p>
+    
+    <p>Please note this user will be created with no guests. It is entirely valid to have accounts to permit login and even admin access that do not have any invited guests attached to the account.</p>
+
+    <div class="row">
+        <div class="col-md-4">
+            <p>@Message</p>
+            <EditForm Model="Input" asp-route-returnUrl="/" method="post" OnValidSubmit="RegisterUser" FormName="register">
+                <DataAnnotationsValidator />
+                <h2>Create an admin account</h2>
+                <p>A reminder to choose a secure password, as this account will have admin access!</p>
+                <hr style="margin-bottom: 5px" />
+                <ValidationSummary class="text-danger" role="alert" />
+                <div class="form-floating">
+                    <label for="email">Email</label>
+                    <MudSpacer/>
+                    <InputText @bind-Value="Input.Email" class="form-control" autocomplete="username" aria-required="true" placeholder="name@example.com" id="email"/>
+                    <ValidationMessage For="() => Input.Email" class="text-danger" />
+                </div>
+                @* <div class="form-floating"> *@
+                @*     <label for="username">Username (Generally first name and surname, but up to you. May be used in the user interface. No need to be unique.)</label> *@
+                @*     <MudSpacer/> *@
+                @*     <InputText @bind-Value="Input.UserName" class="form-control" aria-required="true" placeholder="John Smith" id="username"/> *@
+                @*     <ValidationMessage For="() => Input.UserName" class="text-danger" /> *@
+                @* </div> *@
+                <div class="form-floating">
+                    <label for="password">Password</label>
+                    <MudSpacer/>
+                    <InputText type="password" @bind-Value="Input.Password" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" id="password" />
+                    <ValidationMessage For="() => Input.Password" class="text-danger" />
+                </div>
+                <div class="form-floating mb-3">
+                    <label for="confirm-password">Confirm Password</label>
+                    <MudSpacer/>
+                    <InputText type="password" @bind-Value="Input.ConfirmPassword" class="form-control" autocomplete="new-password" aria-required="true" placeholder="password" id="confirm-password" />
+                    <ValidationMessage For="() => Input.ConfirmPassword" class="text-danger" />
+                </div>
+                <button type="submit">Register</button>
+            </EditForm>
+        </div>
+    </div>
+    
+</Section>
+
+@code {
+    private IEnumerable<IdentityError>? identityErrors;
+
+    [SupplyParameterFromForm]
+    private InputModel Input { get; set; } = new();
+
+    private string? Message => identityErrors is null ? null : $"Error: {string.Join(", ", identityErrors.Select(error => error.Description))}";
+
+    protected override async Task OnInitializedAsync()
+    {
+        await RedirectIfUsersExist();
+    }
+    
+    private async Task RedirectIfUsersExist()
+    {
+        var anyUsers = await UserManager.Users.AnyAsync();
+        if (anyUsers)
+        {
+            RedirectManager.RedirectTo("/");
+        }
+    }
+
+    public async Task RegisterUser(EditContext editContext)
+    {
+        // Check if there are any users already - if so, don't allow setup
+        await RedirectIfUsersExist();
+        
+        // Create the admin role if it doesn't exist
+        if (!await RoleManager.RoleExistsAsync("Admin"))
+        {
+            var roleResult = await RoleManager.CreateAsync(new IdentityRole("Admin"));
+            if (!roleResult.Succeeded)
+            {
+                identityErrors = roleResult.Errors;
+                return;
+            }
+        }
+        
+        Logger.LogInformation("Registering a new admin user.");
+    
+        var user = CreateUser();
+
+        await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
+        await UserManager.AddToRoleAsync(user, "Admin");
+        var emailStore = GetEmailStore();
+        await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
+        var result = await UserManager.CreateAsync(user, Input.Password);
+
+        if (!result.Succeeded)
+        {
+            identityErrors = result.Errors;
+            return;
+        }
+
+        Logger.LogInformation("User created a new account with password.");
+
+        var userId = await UserManager.GetUserIdAsync(user);
+        var code = await UserManager.GenerateEmailConfirmationTokenAsync(user);
+        code = WebEncoders.Base64UrlEncode(Encoding.UTF8.GetBytes(code));
+
+        await SignInManager.SignInAsync(user, isPersistent: false);
+        RedirectManager.RedirectTo("/");
+    }
+
+    private Account CreateUser()
+    {
+        try
+        {
+            return Activator.CreateInstance<Account>();
+        }
+        catch
+        {
+            throw new InvalidOperationException($"Can't create an instance of '{nameof(Account)}'. " +
+                $"Ensure that '{nameof(Account)}' is not an abstract class and has a parameterless constructor.");
+        }
+    }
+
+    private IUserEmailStore<Account> GetEmailStore()
+    {
+        if (!UserManager.SupportsUserEmail)
+        {
+            throw new NotSupportedException("The default UI requires a user store with email support.");
+        }
+        return (IUserEmailStore<Account>)UserStore;
+    }
+
+    private sealed class InputModel
+    {
+        [Required]
+        [EmailAddress]
+        [Display(Name = "Email")]
+        public string Email { get; set; } = "";
+        
+        // [Required]
+        // [Display(Name = "Username")]
+        // public string UserName { get; set; } = "";
+
+        [Required]
+        [StringLength(100, ErrorMessage = "The {0} must be at least {2} and at max {1} characters long.", MinimumLength = 6)]
+        [DataType(DataType.Password)]
+        [Display(Name = "Password")]
+        public string Password { get; set; } = "";
+
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+        public string ConfirmPassword { get; set; } = "";
+    }
+}

--- a/WeddingWebsite/Components/Pages/Auth/Setup.razor.css
+++ b/WeddingWebsite/Components/Pages/Auth/Setup.razor.css
@@ -1,0 +1,32 @@
+﻿h1 {
+    margin-top: 100px;
+    margin-bottom: 10px;
+}
+
+p {
+    margin-bottom: 5px;
+}
+
+h2 {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}
+
+.form-floating {
+    display: flex;
+    margin-bottom: 10px;
+}
+
+button {
+    background: var(--primary);
+    box-shadow: 1px 2px 6px rgba(0,0,0,0.2);
+    font-size: 18px;
+    border-radius: 5px;
+    padding: 5px 10px;
+    margin-top: 20px;
+    margin-left: 45%; /* Yes, I am that lazy */
+}
+
+button:hover {
+    box-shadow: 1px 2px 12px rgba(0,0,0,0.4);
+}

--- a/WeddingWebsite/Data/Stores/IStore.cs
+++ b/WeddingWebsite/Data/Stores/IStore.cs
@@ -9,4 +9,9 @@ public interface IStore
     /// Retrieve all guests associated with a specific user. Each guest is associated with exactly one user.
     /// </summary>
     public IEnumerable<GuestResponse> GetGuestsForUser(string userId);
+    
+    /// <summary>
+    /// Adds a new guest to the specified user's account. Restricted to Admin users.
+    /// </summary>
+    public void AddGuestToAccount(string userId, string firstName, string lastName);
 }

--- a/WeddingWebsite/Data/Stores/Store.cs
+++ b/WeddingWebsite/Data/Stores/Store.cs
@@ -39,4 +39,25 @@ public class Store : IStore
 
         return guests;
     }
+    
+    [Authorize(Roles = "Admin")]
+    public void AddGuestToAccount(string userId, string firstName, string lastName)
+    {
+        using var connection = new SqliteConnection("DataSource=Data\\app.db;Cache=Shared");
+        connection.Open();
+        
+        var command = connection.CreateCommand();
+        command.CommandText =
+        @"
+            INSERT INTO Guests (GuestId, UserId, FirstName, LastName, RsvpStatus)
+            VALUES (:guestId, :userId, :firstName, :lastName, :rsvpStatus)
+        ";
+        command.Parameters.AddWithValue(":guestId", Guid.NewGuid().ToString());
+        command.Parameters.AddWithValue(":userId", userId);
+        command.Parameters.AddWithValue(":firstName", firstName);
+        command.Parameters.AddWithValue(":lastName", lastName);
+        command.Parameters.AddWithValue(":rsvpStatus", RsvpStatusEnumConverter.RsvpStatusToDatabaseInteger(RsvpStatus.NotResponded));
+
+        command.ExecuteNonQuery();
+    }
 }

--- a/WeddingWebsite/Program.cs
+++ b/WeddingWebsite/Program.cs
@@ -31,6 +31,7 @@ builder.Services.AddScoped<IGoogleMapsApiKey, Credentials>();
 builder.Services.AddScoped<IDetailsAndConfigValidator, DetailsAndConfigValidator>();
 builder.Services.AddScoped<RsvpController>();
 builder.Services.AddScoped<IRsvpService, RsvpService>();
+builder.Services.AddScoped<IAdminService, AdminService>();
 builder.Services.AddScoped<IStore, Store>();
 
 builder.Services.AddRazorComponents()

--- a/WeddingWebsite/Program.cs
+++ b/WeddingWebsite/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddIdentityCore<Account>(options => {
     options.User.RequireUniqueEmail = true;
     options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
 })
+    .AddRoles<IdentityRole>()
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddSignInManager()
     .AddDefaultTokenProviders();

--- a/WeddingWebsite/Program.cs
+++ b/WeddingWebsite/Program.cs
@@ -62,6 +62,8 @@ builder.Services.AddIdentityCore<Account>(options => {
     options.Password.RequireNonAlphanumeric = false;
     options.Password.RequireUppercase = false;
     options.SignIn.RequireConfirmedAccount = false;
+    options.User.RequireUniqueEmail = true;
+    options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
 })
     .AddEntityFrameworkStores<ApplicationDbContext>()
     .AddSignInManager()

--- a/WeddingWebsite/Services/AdminService.cs
+++ b/WeddingWebsite/Services/AdminService.cs
@@ -1,9 +1,13 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using WeddingWebsite.Data.Stores;
 
 namespace WeddingWebsite.Services;
 
 [Authorize (Roles = "Admin")]
-public class AdminService
+public class AdminService(IStore store) : IAdminService
 {
-    
+    public void AddGuestToAccount(string userId, string firstName, string lastName)
+    {
+        store.AddGuestToAccount(userId, firstName, lastName);
+    }
 }

--- a/WeddingWebsite/Services/IAdminService.cs
+++ b/WeddingWebsite/Services/IAdminService.cs
@@ -1,0 +1,6 @@
+﻿namespace WeddingWebsite.Services;
+
+public interface IAdminService
+{
+    void AddGuestToAccount(string userId, string firstName, string lastName);
+}


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds a page `/account/setup` designed for first-time setup. This page is disabled once there is at least one account in the database.
Makes the page `/account/register` work as designed to create an account. Only admin users can create accounts.

<img width="773" height="580" alt="image" src="https://github.com/user-attachments/assets/f0d4ddae-e7e3-4f48-b4f2-42d6bbea70b8" />

## Does this affect the IWeddingDetails interface?
No.

## Are you overriding the default behaviour, or have you added it behind a config option?
New admin-facing pages only.

## Does any validation logic need adding/updating?
No.

## Any other comments?
No.

## Does this close any issues?
No.
