### PR TITLE
Add custom 404 page

### DIFF
--- a/WeddingWebsite/Components/Pages/NotFound.razor
+++ b/WeddingWebsite/Components/Pages/NotFound.razor
@@ -1,0 +1,19 @@
+﻿@page "/{*Path:nonfile}"
+
+@using WeddingWebsite.Components.Layouts
+
+@layout MainLayout
+
+<div class="not-found-container">
+    <h1>404</h1>
+    <h2>Not Found</h2>
+
+    <p>The path <code>@Path</code> does not exist.</p>
+
+    <p class="end-button"><a href="/">Back to Homepage</a></p>
+</div>
+
+@code {
+    [Parameter]
+    public required string Path { get; set; }
+}

--- a/WeddingWebsite/Components/Pages/NotFound.razor.css
+++ b/WeddingWebsite/Components/Pages/NotFound.razor.css
@@ -1,0 +1,30 @@
+﻿.not-found-container {
+    text-align: center;
+    margin-top: 150px;
+}
+
+h1 {
+    font-size: 72px;
+    margin-bottom: 20px;
+}
+
+h2 {
+    font-size: 32px;
+    margin-bottom: 30px;
+}
+
+p {
+    font-size: 18px;
+    margin-bottom: 10px;
+    color: #666;
+}
+
+a {
+    color: var(--primary);
+    font-size: 18px;
+    text-decoration: none;
+}
+
+.end-button {
+    margin-top: 50px;
+}

--- a/WeddingWebsite/Components/Routes.razor
+++ b/WeddingWebsite/Components/Routes.razor
@@ -1,9 +1,13 @@
 ﻿@using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Components.Pages
 <CascadingAuthenticationState>
     <Router AppAssembly="typeof(Program).Assembly">
         <Found Context="routeData">
             <AuthorizeRouteView RouteData="routeData" DefaultLayout="typeof(MainLayout)"/>
             <FocusOnNavigate RouteData="routeData" Selector="h1"/>
         </Found>
+        <NotFound>
+            <NotFound Path=""/>
+        </NotFound>
     </Router>
 </CascadingAuthenticationState>


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds a very basic 404 page to look better than the browser default.
<img width="1919" height="916" alt="image" src="https://github.com/user-attachments/assets/59fdf9c1-32b5-4495-9987-191e5a922617" />

## What will existing users have to change when pulling these changes?
Nothing.

## Are you overriding the default behaviour, or have you added it behind a config option?
Extra pages, no config.

## Does any validation logic need adding/updating?
No.

## Any interesting design decisions?
Not super happy with it. If you type `//x` then it'll trigger the `<NotFound>` in the routing, otherwise it hits the `<Found>` bit but then errors out earlier, hence the page to match no file.

## Does this close any issues?
Closes #34
