### PR TITLE
Account deletion

### DIFF
--- a/WeddingWebsite/Components/Layouts/SimpleLayout.razor.css
+++ b/WeddingWebsite/Components/Layouts/SimpleLayout.razor.css
@@ -63,6 +63,10 @@
     background: #aaa;
 }
 
+::deep .red-button {
+    background: #ff5b5b;
+}
+
 ::deep button:hover, ::deep .button:hover {
     box-shadow: 1px 2px 12px rgba(0,0,0,0.4);
 }
@@ -84,4 +88,11 @@
 
 ::deep .text-red {
     color: red;
+}
+
+::deep .flex-center-column {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: center;
 }

--- a/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
@@ -129,7 +129,24 @@
     </PagerContent>
 </MudTable>
 
-<div class="text-center">
+<div class="narrow-section">
+    <AuthorizeView Roles="Owner">
+        <Authorized>
+            @if (DeletePressedCount == 0)
+            {
+                <button class="button red-button block-button" @onclick="PressDelete">Delete Account</button>
+            } else if (DeletePressedCount == 1)
+            {
+                <p class="text-red">Are you sure you want to delete this account? This action cannot be undone.</p>
+                <button class="button red-button block-button" @onclick="PressDelete">Delete Account (press again to confirm)</button>
+            } else if (DeletePressedCount == 2)
+            {
+                <p class="text-red">Are you super duper sure? All logs associated with this account will be lost. There is absolutely no way to recover this data.</p>
+                <button class="button red-button block-button" @onclick="DeleteAccount">Delete Account (this is the final warning)</button>
+            }
+        </Authorized>
+    </AuthorizeView>
+    
     <a class="button grey-button" href="/admin">Back to Admin Page</a>
 </div>
 
@@ -148,6 +165,8 @@
     private bool SomethingDiffers => EmailDiffers != "" || PasswordDiffers != "";
     private string EmailDiffers => Account is null || Account.Email == Email ? "" : "input-error";
     private string PasswordDiffers => NewPassword == "" ? "" : "input-error";
+    
+    private int DeletePressedCount { get; set; } = 0;
     
     private ClaimsPrincipal LoggedInUser { get; set; }
 
@@ -275,6 +294,27 @@
         {
             AccountService.Log(LoggedInUser, AccountLogType.ChangePermissions, "Promoted from User to Admin", UserId);
             Logs = AdminService.GetAccountLogs(UserId);
+        }
+    }
+
+    private void PressDelete()
+    {
+        DeletePressedCount++;
+    }
+    
+    [Authorize (Roles = "Owner")]
+    private void DeleteAccount()
+    {
+        if (Account is null) return;
+        
+        var result = UserManager.DeleteAsync(Account).Result;
+        if (!result.Succeeded)
+        {
+            ErrorText = string.Join(" ", result.Errors.Select(e => e.Description));
+        }
+        else
+        {
+            NavigationManager.NavigateTo("/admin");
         }
     }
 


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Before pressing:
<img width="822" height="650" alt="image" src="https://github.com/user-attachments/assets/51fd9578-8708-4cf5-aae9-3f1bd99a72b0" />

First press:
<img width="402" height="137" alt="image" src="https://github.com/user-attachments/assets/65fb0c18-df7a-457d-9572-4e9014dc16ad" />

Second press:
<img width="415" height="156" alt="image" src="https://github.com/user-attachments/assets/c8cba5f8-fd9f-4a63-bd0d-2688db1fbec0" />

Third press deletes the account and redirects back to `/admin`

## What will existing users have to change when pulling these changes?
Nothing.

## Are you overriding the default behaviour, or have you added it behind a config option?
Default behaviour in admin site only.

## Does any validation logic need adding/updating?
No.

## Any interesting design decisions?
I considered using soft-delete by adding an `IsDeleted` field, but ultimately decided it wasn't worth the bother.

## Does this close any issues?
Closes #54