### PR TITLE
Prevent admins from modifying owner account

### DIFF
--- a/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
@@ -39,7 +39,18 @@
         <label for="email">Email</label>
         <span class="flex-grow"></span>
         <input @bind-value="Email" id="email" class="mr @EmailDiffers" />
-        <button @onclick="ApplyEmailChange">Apply</button>
+        @if (!IsUserOwner())
+        {
+            <button @onclick="ApplyEmailChange">Apply</button>
+        }
+        else
+        {
+            <AuthorizeView Roles="Owner">
+                <Authorized>
+                    <button @onclick="ApplyEmailChange">Apply</button>
+                </Authorized>
+            </AuthorizeView>
+        }
     </div>
 
     @if (!IsUserOwner())

--- a/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
@@ -42,12 +42,15 @@
         <button @onclick="ApplyEmailChange">Apply</button>
     </div>
 
-    <div class="flex-container mb">
-        <label for="new-password">New Password</label>
-        <span class="flex-grow"></span>
-        <input type="password" @bind-value="NewPassword" id="new-password" class="mr @PasswordDiffers" placeholder="Reset their password" />
-        <button @onclick="ApplyPasswordChange">Apply</button>
-    </div>
+    @if (!IsUserOwner())
+    {
+        <div class="flex-container mb">
+            <label for="new-password">New Password</label>
+            <span class="flex-grow"></span>
+            <input type="password" @bind-value="NewPassword" id="new-password" class="mr @PasswordDiffers" placeholder="Reset their password" />
+            <button @onclick="ApplyPasswordChange">Apply</button>
+        </div>
+    }
     
     <h2>Guests</h2>
     <p>Click on a guest to manage/delete them.</p>


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Fixes a critical vulnerability whereby admins can reset the password of the owner account to gain access themselves. It also prevents them from changing the email, which is also disruptive although won't grant them access.

<img width="443" height="351" alt="image" src="https://github.com/user-attachments/assets/05a6a5c5-39e9-4338-b987-8ac42c21200d" />

An owner who wants to reset their password must do so on the "manage account" page. Changing emails is still possible on this page as this is not an option for users to manage themselves.

## What will existing users have to change when pulling these changes?
Nothing.

## Are you overriding the default behaviour, or have you added it behind a config option?
Default (admin site only).

## Does any validation logic need adding/updating?
No.

## Any interesting design decisions?
No.

## Does this close any issues?
Closes #49
