### PR TITLE
Add gallery page

### DIFF
--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -1,27 +1,29 @@
 ﻿@page "/Gallery"
 
-@using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Models.WeddingDetails
-
-@layout SimpleLayout
 
 @inject IWeddingDetails WeddingDetails
 
-<h1>Gallery</h1>
-<p>We'll be sharing a selection of our pictures following the event.</p>
+<div style="margin-top: 50px;"></div>
 
-@foreach (var sect in WeddingDetails.Gallery.Sections)
-{
-    <h2>@sect.Title</h2>
-    <p>@sect.Description</p>
-    <div class="gallery-images">
-        @foreach (var img in sect.Items)
-        {
-            <img class="gallery-image" src="@img.Image.Url" alt="@img.Image.AltText" />
-        }
-    </div>
+<Section>
+    <SectionHeading>Gallery</SectionHeading>
+
+    @foreach (var sect in WeddingDetails.Gallery.Sections)
+    {
+        <h2>@sect.Title</h2>
+        <p>@sect.Description</p>
+        <div class="gallery-images">
+            @foreach (var img in sect.Items)
+            {
+                <img class="gallery-image" src="@img.Image.Url" alt="@img.Image.AltText" />
+            }
+        </div>
     
-}
+    }
+</Section>
+
 
 @code {
     

--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -14,10 +14,13 @@
 {
     <h2>@sect.Title</h2>
     <p>@sect.Description</p>
-    @foreach (var img in sect.Items)
-    {
-        @((MarkupString)img.Image.GetHtml())
-    }
+    <div class="gallery-images">
+        @foreach (var img in sect.Items)
+        {
+            <img class="gallery-image" src="@img.Image.Url" alt="@img.Image.AltText" />
+        }
+    </div>
+    
 }
 
 @code {

--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -17,7 +17,7 @@
         <div class="gallery-images">
             @foreach (var img in sect.Items)
             {
-                <img class="gallery-image" src="@img.Image.Url" alt="@img.Image.AltText" />
+                <img class="gallery-image" src="@img.Image.Url" alt="@img.Image.AltText" style="grid-column: span @img.Size" />
             }
         </div>
     

--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -1,11 +1,24 @@
 ﻿@page "/Gallery"
 
 @using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Models.WeddingDetails
 
 @layout SimpleLayout
 
+@inject IWeddingDetails WeddingDetails
+
 <h1>Gallery</h1>
 <p>We'll be sharing a selection of our pictures following the event.</p>
+
+@foreach (var sect in WeddingDetails.Gallery.Sections)
+{
+    <h2>@sect.Title</h2>
+    <p>@sect.Description</p>
+    @foreach (var img in sect.Items)
+    {
+        @((MarkupString)img.Image.GetHtml())
+    }
+}
 
 @code {
     

--- a/WeddingWebsite/Components/Pages/Gallery.razor.css
+++ b/WeddingWebsite/Components/Pages/Gallery.razor.css
@@ -9,3 +9,13 @@
     height: 100%;
     object-fit: cover;
 }
+
+h2 {
+    margin-bottom: 5px;
+    margin-top: 20px;
+    font-size: 28px;
+}
+
+p {
+    margin-bottom: 10px;
+}

--- a/WeddingWebsite/Components/Pages/Gallery.razor.css
+++ b/WeddingWebsite/Components/Pages/Gallery.razor.css
@@ -1,6 +1,6 @@
 ﻿.gallery-images {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
     gap: 10px;
 }
 

--- a/WeddingWebsite/Components/Pages/Gallery.razor.css
+++ b/WeddingWebsite/Components/Pages/Gallery.razor.css
@@ -1,0 +1,9 @@
+﻿.gallery-images {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px;
+}
+
+.gallery-image {
+    width: 100%;
+}

--- a/WeddingWebsite/Components/Pages/Gallery.razor.css
+++ b/WeddingWebsite/Components/Pages/Gallery.razor.css
@@ -6,4 +6,6 @@
 
 .gallery-image {
     width: 100%;
+    height: 100%;
+    object-fit: cover;
 }

--- a/WeddingWebsite/Models/Gallery/GalleryItem.cs
+++ b/WeddingWebsite/Models/Gallery/GalleryItem.cs
@@ -2,7 +2,7 @@
 
 namespace WeddingWebsite.Models.Gallery;
 
-public record GalleryItem(WebsiteImage Image)
+public record GalleryItem(WebsiteImage Image, int Size = 1)
 {
     /// <summary>
     /// Create a gallery item with a URL image and no alt text.

--- a/WeddingWebsite/Models/Gallery/GalleryItem.cs
+++ b/WeddingWebsite/Models/Gallery/GalleryItem.cs
@@ -1,0 +1,11 @@
+﻿using WeddingWebsite.Models.WebsiteElement;
+
+namespace WeddingWebsite.Models.Gallery;
+
+public record GalleryItem(WebsiteImage Image)
+{
+    /// <summary>
+    /// Create a gallery item with a URL image and no alt text.
+    /// </summary>
+    public GalleryItem(string url) : this(new WebsiteImage(url, null)) {}
+}

--- a/WeddingWebsite/Models/Gallery/GalleryItems.cs
+++ b/WeddingWebsite/Models/Gallery/GalleryItems.cs
@@ -1,0 +1,9 @@
+﻿using WeddingWebsite.Models.WebsiteElement;
+
+namespace WeddingWebsite.Models.Gallery;
+
+/// <summary>
+/// All content for the gallery section.
+/// </summary>
+/// <param name="Items">Items, organised by section.</param>
+public record GalleryItems(IEnumerable<GallerySection> Sections);

--- a/WeddingWebsite/Models/Gallery/GallerySection.cs
+++ b/WeddingWebsite/Models/Gallery/GallerySection.cs
@@ -1,0 +1,7 @@
+﻿namespace WeddingWebsite.Models.Gallery;
+
+public record GallerySection(
+    IEnumerable<GalleryItem> Items, 
+    string? Title = null,
+    string? Description = null
+);

--- a/WeddingWebsite/Models/WeddingDetails/IWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/IWeddingDetails.cs
@@ -1,4 +1,5 @@
-﻿using WeddingWebsite.Models.People;
+﻿using WeddingWebsite.Models.Gallery;
+using WeddingWebsite.Models.People;
 using WeddingWebsite.Models.Venues;
 using WeddingWebsite.Models.WebsiteConfig;
 using WeddingWebsite.Models.WebsiteElement;
@@ -48,6 +49,11 @@ public interface IWeddingDetails
     /// to unauthenticated users.
     /// </summary>
     public WebsiteImage MainImage { get; }
+    
+    /// <summary>
+    /// Images to show on the gallery page.
+    /// </summary>
+    public GalleryItems Gallery { get; }
     
     /// <summary>
     /// Used for the "how we met" section.

--- a/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
+++ b/WeddingWebsite/Models/WeddingDetails/SampleWeddingDetails.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using WeddingWebsite.Models.Gallery;
 using WeddingWebsite.Models.People;
 using WeddingWebsite.Models.Venues;
 using WeddingWebsite.Models.WebsiteConfig;
@@ -279,7 +280,20 @@ public sealed class SampleWeddingDetails : IWeddingDetails
     public WebsiteImage MainImage { get; } 
         = new WebsiteImage("https://images.squarespace-cdn.com/content/v1/60167718645a930edf99bede/6fb36556-54ab-4a9e-9224-be3ef81587e5/K%2BM+-+Pheasantry+Brewery+Wedding+27.jpg", "An image of the bride and groom hugging surrounded by the wedding guests taking pictures.");
         
-    public IEnumerable<WebsiteImage> GalleryImages { get; } = new List<WebsiteImage>();
+    public GalleryItems Gallery { get; } = new ([
+        new GallerySection(
+            [
+                new GalleryItem("https://pm1.aminoapps.com/6549/18b7f2ae94d82dbe03c54e4e8de0f17211236d70_hq.jpg"),
+                new GalleryItem("https://i.ytimg.com/vi/GAyzLbpZeKE/maxresdefault.jpg"),
+                new GalleryItem("https://ih1.redbubble.net/image.5821996399.7493/fposter,small,wall_texture,square_product,600x600.jpg"),
+                new GalleryItem("https://pbs.twimg.com/media/EbN2CI3WAAcVxXD?format=jpg&name=large"),
+                new GalleryItem("https://pbs.twimg.com/media/GfagNwOWQAAFWlB?format=jpg&name=medium"),
+                new GalleryItem("https://i.ytimg.com/vi/9tcHOMOVfrk/hq720.jpg?sqp=-oaymwEhCK4FEIIDSFryq4qpAxMIARUAAAAAGAElAADIQj0AgKJD&rs=AOn4CLDJ8fvK_Ob-YZ66NKdIqKydgxvhZQ"),
+            ], 
+            "General Pictures", 
+            "Aren't they having such a happy life together..."
+        )
+    ]);
     
     public WebsiteLink RegistryLink { get; }
         = new WebsiteLink("https://youtu.be/dQw4w9WgXcQ");


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds pictures to the gallery page.
<img width="1035" height="829" alt="image" src="https://github.com/user-attachments/assets/7473050e-9857-4bf8-957e-a550c14cb1b3" />

## What will existing users have to change when pulling these changes?
Users must implement the new property `Gallery` in `IWeddingDetails`. If you're not interested in the gallery, simply add `public GalleryItems Gallery => new GalleryItems([]);` to get your code to compile.

## Are you overriding the default behaviour, or have you added it behind a config option?
This is introducing planned behaviour.

## Does any validation logic need adding/updating?
I think it's okay aside from major edge cases (e.g. absurd size values).

## Any interesting design decisions?
I'm using CSS grid to display them with `object-fit: cover`. I was very reluctant to do anything outside of pure CSS to get them to display nicely, and I think this approach is pretty good.

## Does this close any issues?
Nope.
