### PR TITLE
Replace hidden items section with filter

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -53,7 +53,7 @@
                 }
                 <h2 class="grid-heading">Other Registry Items</h2>
             }
-            @foreach (var item in SortedAndFilteredItems.Where(item => UserId == null || item.NumClaimsByUser(UserId) == 0).Where(item => !item.Hide))
+            @foreach (var item in SortedAndFilteredItems.Where(item => UserId == null || item.NumClaimsByUser(UserId) == 0))
             {
                 <div class="gift">
                     <RegistryItem Item="item" ButtonText="@(item.IsFullyClaimed ? "Claimed" : "Available")" ButtonSuccess="@(!item.IsFullyClaimed)"/>
@@ -70,24 +70,6 @@
                     <p class="grid-heading">There are no items matching the selected filters.</p>
                 }
             }
-            <AuthorizeView Roles="Admin">
-                <Authorized>
-                    <h2 class="grid-heading">Hidden Items (Admin Only)</h2>
-                    @if (RegistryItems.Any(item => item.Hide))
-                    {
-                        @foreach (var item in RegistryItems.Where(item => item.Hide))
-                        {
-                            <div class="gift">
-                                <RegistryItem Item="item" ButtonText="@(item.IsFullyClaimed ? "Claimed" : "Available")" ButtonSuccess="@(!item.IsFullyClaimed)"/>
-                            </div>
-                        }
-                    }
-                    else
-                    {
-                        <p class="grid-heading">There are no hidden items. If you mark an item as hidden, it won't appear in search results but it will be available to claim if people obtain the link to it.</p>
-                    }
-                </Authorized>
-            </AuthorizeView>
         </div>
         <AuthorizeView Roles="Admin">
             <Authorized>
@@ -104,7 +86,6 @@
     private IEnumerable<RegistryItem> RegistryItems { get; set; } = [];
     private IEnumerable<RegistryItem> SortedAndFilteredItems => RegistryItems
         .Where(ItemMatchesFilter)
-        .Where(item => !item.Hide)
         .OrderBy(item =>
         {
             switch (CurrentSortOrder)
@@ -135,7 +116,8 @@
         "Claimed: Bring on day",
         "Claimed: Deliver to us",
         "Claimed: Pending",
-        "Claimed: Completed"
+        "Claimed: Completed",
+        "Hidden"
     ];
 
     private enum SortOrder
@@ -195,6 +177,15 @@
             return false;
         }
         if (EnabledFilters.Contains("Claimed: Completed") && item.Claims.All(c => !c.IsCompleted))
+        {
+            return false;
+        }
+        // Hidden items are only shown when the "Hidden" filter is enabled (which then shows only hidden items)
+        if (item.Hide && !EnabledFilters.Contains("Hidden"))
+        {
+            return false;
+        }
+        if (!item.Hide && EnabledFilters.Contains("Hidden"))
         {
             return false;
         }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Replaces the hidden items section with a filter. This puts less emphasis on the hidden items and makes it easier to use. The original hidden items section was developed before filters were introduced.

Old:
<img width="1055" height="951" alt="image" src="https://github.com/user-attachments/assets/381a487b-3551-4fc5-85ef-e8801927943e" />

New:
<img width="1051" height="1003" alt="image" src="https://github.com/user-attachments/assets/cfea575a-7b65-421c-800c-031d6f861105" />
<img width="1026" height="987" alt="image" src="https://github.com/user-attachments/assets/8ad2d380-7736-446a-8bbd-480c53bd221d" />

## What will existing users have to change when pulling these changes?
Nothing.

## Are you overriding the default behaviour, or have you added it behind a config option?
Overriding default behaviour - the new behaviour is definitely better.

## Does any validation logic need adding/updating?
No.

## Any interesting design decisions?
The "hidden" filter will also hide non-hidden items. This seemed like the most useful way of doing it, although it is not possible to view both hidden and non-hidden items together - this would need another filter.

## Does this close any issues?
Closes #76