### PR TITLE
Add delete button to registry

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/ManageRegistryItem.razor
+++ b/WeddingWebsite/Components/Pages/Registry/ManageRegistryItem.razor
@@ -104,15 +104,23 @@
     <div>
         <button type="submit" class="button block-button">Save Changes</button>
     </div>
-    @if (deleteConfirm)
+    @if (Item.Claims.Any())
     {
-        <p class="text-danger">Are you sure you want to delete this item? This action cannot be undone.</p>
-        <button type="button" class="button block-button red-button" @onclick="DeleteItem">Delete Item (cannot be undone)</button>
+        <p>You cannot delete this item as it has already been claimed. Either hide the item, or remove the claim(s) before deleting.</p>
     }
     else
     {
-        <button type="button" class="button block-button red-button" @onclick="() => deleteConfirm = true">Delete Item</button>
+        @if (deleteConfirm)
+        {
+            <p class="text-danger">Are you sure you want to delete this item? This action cannot be undone.</p>
+            <button type="button" class="button block-button red-button" @onclick="DeleteItem">Delete Item (cannot be undone)</button>
+        }
+        else
+        {
+            <button type="button" class="button block-button red-button" @onclick="() => deleteConfirm = true">Delete Item</button>
+        }
     }
+    
     
 </EditForm>
 
@@ -124,11 +132,12 @@
     private EditRegistryItemModel Model { get; set; } = new();
     
     private bool deleteConfirm = false;
+    private RegistryItem? Item { get; set; }
 
     protected override void OnInitialized()
     {
-        var item = RegistryService.GetRegistryItemById(ItemId);
-        if (item == null)
+        Item = RegistryService.GetRegistryItemById(ItemId);
+        if (Item == null)
         {
             NavigationManager.NavigateTo("/Registry");
             return;
@@ -136,14 +145,14 @@
         
         Model = new EditRegistryItemModel
         {
-            GenericName = item.GenericName,
-            Name = item.Name,
-            Description = item.Description,
-            ImageUrl = item.ImageUrl ?? "",
-            Quantity = item.MaxQuantity,
-            Priority = item.Priority,
-            Hide = item.Hide,
-            PurchaseMethods = item.PurchaseMethods.Select(pm => new EditRegistryItemModel.PurchaseMethodModel
+            GenericName = Item.GenericName,
+            Name = Item.Name,
+            Description = Item.Description,
+            ImageUrl = Item.ImageUrl ?? "",
+            Quantity = Item.MaxQuantity,
+            Priority = Item.Priority,
+            Hide = Item.Hide,
+            PurchaseMethods = Item.PurchaseMethods.Select(pm => new EditRegistryItemModel.PurchaseMethodModel
             {
                 Id = pm.Id,
                 Name = pm.Name,
@@ -193,6 +202,18 @@
     
     private void DeleteItem()
     {
+        Item = RegistryService.GetRegistryItemById(ItemId);
+        if (Item == null)
+        {
+            NavigationManager.NavigateTo("/Registry");
+            return;
+        }
+
+        if (Item.Claims.Any())
+        {
+            deleteConfirm = false;
+            return;
+        }
         RegistryService.DeleteItem(ItemId);
         NavigationManager.NavigateTo("/Registry");
     }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds a delete button to the manage item page. Needs to be clicked twice, but after that it cannot be reversed.

<img width="498" height="151" alt="image" src="https://github.com/user-attachments/assets/8a61fb28-426c-4c1b-9dbb-2539166d8d8a" />

Items that have claims on them may not be deleted:
<img width="739" height="129" alt="image" src="https://github.com/user-attachments/assets/714bcd3d-8004-4f34-aa2d-45a14232a1d6" />

## What will existing users have to change when pulling these changes?
Nothing

## Are you overriding the default behaviour, or have you added it behind a config option?
Default behaviour.

## Does any validation logic need adding/updating?
Nope.

## Any interesting design decisions?
Not really. Only concern is that the registry could now be wiped by a malicious admin, but it was already possible to edit items to remove all useful information from them.

## Does this close any issues?
Closes #81
