### PR TITLE
Make validation issues screen prettier

### DIFF
--- a/WeddingWebsite/Components/WeddingComponents/ValidationIssuesList.razor
+++ b/WeddingWebsite/Components/WeddingComponents/ValidationIssuesList.razor
@@ -3,18 +3,11 @@
 @if (Issues.Any(issue => issue.Severity != ValidationIssueSeverity.Info)) {
     <div class="container">
         <h2>Validation Issues</h2>
-        <p>The validator has noticed some issues in your wedding details and/or website config. Fixing these issues is highly recommended to avoid unexpected behaviour on the website. This window is not visible in production.</p>
+        <p>You have some issues that you should fix to ensure everything is displayed correctly. Don't worry, this ugly red window won't be visible in production!</p>
         <h3>Errors</h3>
-        <p>Errors are highly likely to cause incorrect information to be displayed or cause sections to not work properly.</p>
         <ValidationIssuesForSeverity Issues="@Issues.Where(issue => issue.Severity == ValidationIssueSeverity.Error)" />
         <h3>Warnings</h3>
-        <p>Warnings are flagged when the configuration is unusual, but won't necessarily cause any problems in the rendered website.</p>
         <ValidationIssuesForSeverity Issues="@Issues.Where(issue => issue.Severity == ValidationIssueSeverity.Warning)" />
-        @if (Issues.Any(issue => issue.Severity == ValidationIssueSeverity.Info)) {
-            <h3>Info</h3>
-            <p>Info messages may be useful to understand more about how the configuration works. This section isn't shown if all messages are info.</p>
-            <ValidationIssuesForSeverity Issues="@Issues.Where(issue => issue.Severity == ValidationIssueSeverity.Info)" />
-        }
     </div>
 }
 


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Makes the validation issues screen prettier, reducing the amount of text and making it a bit more friendly. Info messages are removed (now only shown on the terminal) as the terminal is seen as descriptive enough, and putting them here was just confusing as it's not actually a problem that needs solving.

Old:
<img width="984" height="422" alt="image" src="https://github.com/user-attachments/assets/498ddb12-a45c-47a6-8982-3fa6be97ffb6" />

New:
<img width="991" height="246" alt="image" src="https://github.com/user-attachments/assets/228318ef-606a-4c50-b0f9-83af6763095d" />

## What will existing users have to change when pulling these changes?
Nothing.

## Are you overriding the default behaviour, or have you added it behind a config option?
Overriding default behaviour of an unimportant thing that does not affect end users.

## Does any validation logic need adding/updating?
No.

## Any interesting design decisions?
No.

## Does this close any issues?
Nope.
