### PR TITLE
Fix bug with account setup

### DIFF
--- a/WeddingWebsite/Components/Pages/Auth/Setup.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Setup.razor
@@ -122,11 +122,11 @@
         var user = CreateUser();
 
         await UserStore.SetUserNameAsync(user, Input.Email, CancellationToken.None);
-        await UserManager.AddToRoleAsync(user, "Admin");
-        await UserManager.AddToRoleAsync(user, "Owner");
         var emailStore = GetEmailStore();
         await emailStore.SetEmailAsync(user, Input.Email, CancellationToken.None);
         var result = await UserManager.CreateAsync(user, Input.Password);
+        await UserManager.AddToRoleAsync(user, "Owner");
+        await UserManager.AddToRoleAsync(user, "Admin");
 
         if (!result.Succeeded)
         {


### PR DESCRIPTION
## What does this PR do, and why do we need it?
The account setup did not work. This is because the CreateUser() method merely makes an object, but does not add the user to the database. The user needs to be added to the database before it can be assigned roles.

## What will existing users have to change when pulling these changes?
N/A

## Are you overriding the default behaviour, or have you added it behind a config option?
N/A

## Does any validation logic need adding/updating?
Nope

## Any interesting design decisions?
Nope

## Does this close any issues?
Closes #99
