### PR TITLE
Display quantity on registry item

### DIFF
--- a/WeddingWebsite/Components/WeddingComponents/RegistryItem.razor
+++ b/WeddingWebsite/Components/WeddingComponents/RegistryItem.razor
@@ -20,10 +20,10 @@
                 {
                     @if (ButtonText is "Pending" or "Completed" && Item.MaxQuantity > 1)
                     {
-                        <p><span class="cost">@StringProvider.CurrencyAmount(Item.CheapestCost)</span> x @Item.QuantityClaimed</p>
+                        <p><span class="cost">@StringProvider.CurrencyAmount(Item.CheapestCost)</span> × @Item.QuantityClaimed</p>
                     } else if (Item.MaxQuantity-Item.QuantityClaimed > 1)
                     {
-                        <p><span class="cost">@StringProvider.CurrencyAmount(Item.CheapestCost)</span> x @(Item.MaxQuantity-Item.QuantityClaimed)</p>
+                        <p><span class="cost">@StringProvider.CurrencyAmount(Item.CheapestCost)</span> × @(Item.MaxQuantity-Item.QuantityClaimed)</p>
                     }
                     else
                     {


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Displays the quantity for registry items when browsing through, so you can instantly spot if it's one with a higher quantity.
<img width="256" height="312" alt="image" src="https://github.com/user-attachments/assets/3fc67539-8076-4f02-a3b2-e0025591ae77" />

In the "Items You've Claimed" section, it shows the quantity you've claimed (including if this is 1). In the other section, it shows the quantity remaining (but only if this quantity exceeds 1).

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable.

Items with a quantity of more than one were too hidden, often making the price misleading. This update is a strict improvement as it communicates essential information within the space available, and I don't see how anyone wouldn't want this change.

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
The multiplication character is not configurable, but I think this is fairly universal.

## Any interesting design decisions?
Nope, just the intricasies with which quantities to display depending on whether it's claimed. Also, I'm using the button text to infer the state which isn't great but it's easy.

## Does this close any issues?
Nope.
