### PR TITLE
Log registry events

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -377,6 +377,8 @@
         if (!result)
         {
             ErrorText = "Sorry, this item has already been claimed by someone else.";
+            StateHasChanged();
+            return;
         }
 
         ErrorText = "";

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -323,11 +323,11 @@
     private bool RevealClaimsToAdmin { get; set; } = false;
     private string EditUrl => $"/registry/edit/{ItemId}";
 
-    protected override void OnInitialized() 
+    protected override async Task OnInitializedAsync()
     {
         Item = RegistryService.GetRegistryItemById(ItemId);
         
-        var authState = AuthStateProvider.GetAuthenticationStateAsync().Result;
+        var authState = await AuthStateProvider.GetAuthenticationStateAsync();
         LoggedInUser = authState.User;
         if (LoggedInUser.Identity is { IsAuthenticated: true })
         {

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -284,8 +284,8 @@
                                 }
                                 else
                                 {
-                                    <Button OnClick="() => { RegistryService.MarkClaimAsCompleted(Item.Id, claim.UserId); Item = RegistryService.GetRegistryItemById(ItemId); StateHasChanged(); }">Mark as Completed</Button>
-                                    <Button OnClick="() => { RegistryService.UnclaimRegistryItem(Item.Id, claim.UserId); Item = RegistryService.GetRegistryItemById(ItemId); StateHasChanged(); }">Remove Claim (cannot be undone)</Button>
+                                    <Button OnClick="() => { AdminMarkAsCompleted(claim); }">Mark as Completed</Button>
+                                    <Button OnClick="() => { AdminUnclaim(claim); }">Remove Claim (cannot be undone)</Button>
                                 }
                                 <LinkButton Url=@editUrl>Edit</LinkButton>
                             </div>
@@ -513,5 +513,31 @@
         RegistryService.SetClaimNotes(Item.Id, UserId, Notes == "" ? null : Notes);
         Item = RegistryService.GetRegistryItemById(ItemId);
         StateHasChanged();
+    }
+    
+    private void AdminUnclaim(RegistryItemClaim claim)
+    {
+        if (Item == null) return;
+        RegistryService.UnclaimRegistryItem(Item.Id, claim.UserId);
+        Item = RegistryService.GetRegistryItemById(ItemId);
+        StateHasChanged();
+        
+        if (LoggedInUser != null)
+        {
+            AccountService.Log(LoggedInUser, AccountLogType.UnclaimRegistryItem, $"Admin unclaimed registry item: {Item?.GenericName}", claim.UserId);
+        }
+    }
+    
+    private void AdminMarkAsCompleted(RegistryItemClaim claim)
+    {
+        if (Item == null) return;
+        RegistryService.MarkClaimAsCompleted(Item.Id, claim.UserId);
+        Item = RegistryService.GetRegistryItemById(ItemId);
+        StateHasChanged();
+        
+        if (LoggedInUser != null)
+        {
+            AccountService.Log(LoggedInUser, AccountLogType.CompleteRegistryItem, $"Admin marked as completed: {Item?.GenericName}", claim.UserId);
+        }
     }
 }

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -404,6 +404,8 @@
         if (!result)
         {
             ErrorText = "Sorry, we were unable to remove your claim. Please try again later.";
+            StateHasChanged();
+            return;
         }
 
         Item = RegistryService.GetRegistryItemById(ItemId);

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -522,7 +522,13 @@
     private void AdminUnclaim(RegistryItemClaim claim)
     {
         if (Item == null) return;
-        RegistryService.UnclaimRegistryItem(Item.Id, claim.UserId);
+        var result = RegistryService.UnclaimRegistryItem(Item.Id, claim.UserId);
+        if (!result)
+        {
+            ErrorText = "Sorry, we were unable to remove this claim. Please try again later.";
+            StateHasChanged();
+            return;
+        }
         Item = RegistryService.GetRegistryItemById(ItemId);
         StateHasChanged();
         

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -6,6 +6,7 @@
 @using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Components.Elements
 @using WeddingWebsite.Core
+@using WeddingWebsite.Models.Accounts
 @using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Models.WebsiteConfig
@@ -15,6 +16,7 @@
 @inject IRegistryService RegistryService
 @inject IWeddingDetails WeddingDetails
 @inject IWebsiteConfig Config
+@inject IAccountService AccountService
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IStringProvider StringProvider
 
@@ -309,6 +311,7 @@
     
     private RegistryItem? Item { get; set; }
     private string? UserId { get; set; }
+    private ClaimsPrincipal? LoggedInUser { get; set; }
     
     private string ErrorText { get; set; } = "";
     private string Notes { get; set; } = "";
@@ -325,10 +328,10 @@
         Item = RegistryService.GetRegistryItemById(ItemId);
         
         var authState = AuthStateProvider.GetAuthenticationStateAsync().Result;
-        var user = authState.User;
-        if (user.Identity != null && user.Identity.IsAuthenticated)
+        LoggedInUser = authState.User;
+        if (LoggedInUser.Identity is { IsAuthenticated: true })
         {
-            UserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            UserId = LoggedInUser.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         }
 
         if (Item != null && UserId != null && Item.NumClaimsByUser(UserId) > 0)
@@ -379,6 +382,11 @@
         ErrorText = "";
         Item = RegistryService.GetRegistryItemById(ItemId);
         StateHasChanged();
+
+        if (LoggedInUser != null)
+        {
+            AccountService.Log(LoggedInUser, AccountLogType.ClaimRegistryItem, "Claimed registry item: " + Item?.GenericName);
+        }
     }
     
     private void RemoveClaim()
@@ -398,6 +406,11 @@
 
         Item = RegistryService.GetRegistryItemById(ItemId);
         StateHasChanged();
+        
+        if (LoggedInUser != null)
+        {
+            AccountService.Log(LoggedInUser, AccountLogType.UnclaimRegistryItem, "Unclaimed registry item: " + Item?.GenericName);
+        }
     }
     
     private void ChooseFulfillmentMethod(FulfillmentMethod? fulfillmentMethod)
@@ -480,6 +493,11 @@
         RegistryService.MarkClaimAsCompleted(Item.Id, UserId);
         Item = RegistryService.GetRegistryItemById(ItemId);
         StateHasChanged();
+        
+        if (LoggedInUser != null)
+        {
+            AccountService.Log(LoggedInUser, AccountLogType.CompleteRegistryItem, "Completed registry item: " + Item?.GenericName);
+        }
     }
     
     private void SaveNotes()

--- a/WeddingWebsite/Data/Enums/AccountLogTypeEnumConverter.cs
+++ b/WeddingWebsite/Data/Enums/AccountLogTypeEnumConverter.cs
@@ -19,6 +19,9 @@ public static class AccountLogTypeEnumConverter
             AccountLogType.SubmitRsvp => 8,
             AccountLogType.DeleteRsvp => 9,
             AccountLogType.EditRsvp => 10,
+            AccountLogType.ClaimRegistryItem => 11,
+            AccountLogType.UnclaimRegistryItem => 12,
+            AccountLogType.CompleteRegistryItem => 13,
             _ => throw new ArgumentOutOfRangeException(nameof(accountLogType), accountLogType, null)
         };
     }
@@ -43,6 +46,9 @@ public static class AccountLogTypeEnumConverter
             8 => AccountLogType.SubmitRsvp,
             9 => AccountLogType.DeleteRsvp,
             10 => AccountLogType.EditRsvp,
+            11 => AccountLogType.ClaimRegistryItem,
+            12 => AccountLogType.UnclaimRegistryItem,
+            13 => AccountLogType.CompleteRegistryItem,
             _ => throw new ArgumentOutOfRangeException(nameof(accountLogType), accountLogType, null)
         };
     }

--- a/WeddingWebsite/Models/Accounts/AccountLogType.cs
+++ b/WeddingWebsite/Models/Accounts/AccountLogType.cs
@@ -35,5 +35,14 @@ public enum AccountLogType
     DeleteRsvp,
     
     [Description("Edit RSVP")]
-    EditRsvp
+    EditRsvp,
+    
+    [Description("Claim registry item")]
+    ClaimRegistryItem,
+    
+    [Description("Unclaim registry item")]
+    UnclaimRegistryItem,
+    
+    [Description("Complete registry item")]
+    CompleteRegistryItem
 }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds new log events for registry events: Claim, Unclaim and Mark as completed. This matches the pattern of similar things like RSVPs having log events. This will help to diagnose if anyone is abusing the feature and leave a history in case things go wrong.

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable.

The general philosophy behind account logs is "the more the better". With normal use, these logs will be very infrequent and so will not be a detriment. It could only get annoying for users that are doing lots of claiming and unclaiming (which they shouldn't be doing).

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
N/A - log strings are for admins only so are not subject to this requirement.

## Any interesting design decisions?
This does permanently store if users were planning on buying something and then later changed their mind, which they may not want to be stored. But since this information was accessible at the time and it isn't particularly sensitive, I think it is okay to leave in.

## Does this close any issues?
Nope.
