### PR TITLE
Add recent activity to admin page

### DIFF
--- a/WeddingWebsite/Components/Admin/AccountList.razor
+++ b/WeddingWebsite/Components/Admin/AccountList.razor
@@ -6,7 +6,7 @@
 @inject IAdminService AdminService
 @inject NavigationManager NavigationManager
 
-<p class="mb">Total guests: <b>@Accounts.Select(account => account.Guests.Count()).Sum()</b>. RSVPs: <b>@Accounts.Select(account => account.Guests.Count(guest => guest.Rsvp != RsvpStatus.NotResponded)).Sum()</b> responded, <b>@Accounts.Select(account => account.Guests.Count(guest => guest.Rsvp == RsvpStatus.Yes)).Sum()</b> attending. <a href="/admin/rsvp/table">View detailed RSVP response table.</a></p>
+<p class="mb">Total guests: <b>@Accounts.Select(account => account.Guests.Count()).Sum()</b>. RSVPs: <b>@Accounts.Select(account => account.Guests.Count(guest => guest.Rsvp != RsvpStatus.NotResponded)).Sum()</b> responded, <b>@Accounts.Select(account => account.Guests.Count(guest => guest.Rsvp == RsvpStatus.Yes)).Sum()</b> attending. <a href="/admin/rsvp/table">View all responses.</a></p>
 
 <MudTable T="AccountWithGuests" Class="mb" RowStyle="cursor: pointer" Items="@Accounts" Filter="new Func<AccountWithGuests, bool>(SearchFilter)" Hover="true" OnRowClick="RowClicked">
     <ToolBarContent>

--- a/WeddingWebsite/Components/Admin/RecentActivity.razor
+++ b/WeddingWebsite/Components/Admin/RecentActivity.razor
@@ -1,0 +1,81 @@
+@using WeddingWebsite.Core
+@using WeddingWebsite.Data.Models
+@using WeddingWebsite.Models.Accounts
+@using WeddingWebsite.Services
+
+@inject IAdminService AdminService
+@inject NavigationManager NavigationManager
+
+<MudTable T="AccountLog" Class="mb" RowStyle="cursor: pointer" Items="@Logs" Filter="new Func<AccountLog, bool>(TypeFilter)" Hover="true" OnRowClick="RowClicked" RowsPerPage="5">
+    <ToolBarContent>
+        <MudText Typo="Typo.h6">Recent Activity</MudText>
+        <MudSpacer />
+        <MudSelect T="string" MultiSelection="true" @bind-Value="EnabledFiltersString" @bind-SelectedValues="EnabledFilters" Label="Filter by Type">
+            @foreach (var filter in AllFilters)
+            {
+                <MudSelectItem T="string" Value="@filter">@filter</MudSelectItem>
+            }
+        </MudSelect>
+    </ToolBarContent>
+    <HeaderContent>
+        <MudTh><MudTableSortLabel SortBy="new Func<AccountLog, object?>(x => x.Date)">When</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<AccountLog, object?>(x => x.AffectedUser.UserName)">Affected User</MudTableSortLabel></MudTh>
+        <MudTh><MudTableSortLabel SortBy="new Func<AccountLog, object?>(x => x.Description)">Description</MudTableSortLabel></MudTh>
+    </HeaderContent>
+    <RowTemplate>
+        <MudTd DataLabel="When">@((DateTime.UtcNow - context.Date).FormatShortDuration()) ago</MudTd>
+        <MudTd DataLabel="Affected User">@context.AffectedUser.UserName</MudTd>
+        <MudTd DataLabel="Description">@context.Description</MudTd>
+    </RowTemplate>
+    <PagerContent>
+        <MudTablePager/>
+    </PagerContent>
+</MudTable>
+
+@code {
+    private IEnumerable<AccountLog> Logs { get; set; } = [];
+    private IEnumerable<string> EnabledFilters { get; set; } = new HashSet<string> { "Log in" };
+    private string EnabledFiltersString { get; set; } = "";
+    private readonly string[] AllFilters =
+    [
+        "Log in",
+        "Account details",
+        "RSVP",
+        "Registry"
+    ];
+    
+    private void RowClicked(TableRowClickEventArgs<AccountLog> args)
+    {
+        if (args.Item == null)
+        {
+            return;
+        }
+        var accountId = args.Item.AffectedUser.Id;
+        NavigationManager.NavigateTo($"/admin/account/{accountId}");
+    }
+
+    protected override void OnInitialized()
+    {
+        Logs = AdminService.GetAllAccountLogs();
+    }
+    
+    private bool TypeFilter(AccountLog log)
+    {
+        var loginTypes = new List<AccountLogType> { AccountLogType.LogIn };
+        var accountDetailsTypes = new List<AccountLogType> { AccountLogType.ChangePassword, AccountLogType.ChangeUserName, AccountLogType.ChangeEmail, AccountLogType.ChangePermissions, AccountLogType.DeleteGuest, AccountLogType.AddGuest, AccountLogType.RenameGuest };
+        var rsvpTypes = new List<AccountLogType> { AccountLogType.SubmitRsvp, AccountLogType.DeleteRsvp, AccountLogType.EditRsvp };
+        var registryTypes = new List<AccountLogType> { AccountLogType.ClaimRegistryItem, AccountLogType.UnclaimRegistryItem, AccountLogType.CompleteRegistryItem };
+        
+        if (!EnabledFilters.Contains("Log in") && loginTypes.Contains(log.LogType))
+            return false;
+        if (!EnabledFilters.Contains("Account details") && accountDetailsTypes.Contains(log.LogType))
+            return false;
+        if (!EnabledFilters.Contains("RSVP") && rsvpTypes.Contains(log.LogType))
+            return false;
+        if (!EnabledFilters.Contains("Registry") && registryTypes.Contains(log.LogType))
+            return false;
+        
+        return true;
+    }
+
+}

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor
@@ -10,18 +10,14 @@
 
 <h1>Admin Page</h1>
 
-<p>Welcome to the admin page. This page is not accessible to non-admin users.</p>
+<div class="links-container">
+    <p>Links:</p>
+    <a href="/account/register" role="button" class="button">Add New Account</a>
+    <a href="/todo" role="button" class="button">Go to To-Do List</a>
+</div>
 
-<h2>Register a new user</h2>
-<p>Only admins can create new accounts.</p>
-<a href="/account/register" role="button" class="button">Register</a>
-
-<h2>To-Do List</h2>
-<p>Keep track of what needs doing without leaving the website, and get reminded about unfinished tasks on the homepage.</p>
-<a href="/todo" role="button" class="button">Go to To-Do List</a>
-
-<h2>Manage user accounts</h2>
-<p>These are all the accounts registered on the website. Click on an account to view more information or update details.</p>
+<h2>User Accounts</h2>
+<p>In this section you can view all of the accounts and update details.</p>
 <AccountList/>
 
 <a class="button grey-button" href="/">Back to Home</a>

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor
@@ -14,6 +14,7 @@
     <p>Links:</p>
     <a href="/account/register" role="button" class="button">Add New Account</a>
     <a href="/todo" role="button" class="button">Go to To-Do List</a>
+    <a href="/admin/rsvp/table" role="button" class="button">View RSVP Responses</a>
 </div>
 
 <h2>User Accounts</h2>

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor
@@ -17,6 +17,10 @@
     <a href="/admin/rsvp/table" role="button" class="button">View RSVP Responses</a>
 </div>
 
+<h2>Recent Activity</h2>
+<p>Check out what's been happening recently. You'll need to opt-in to seeing events other than logins.</p>
+<RecentActivity/>
+
 <h2>User Accounts</h2>
 <p>In this section you can view all of the accounts and update details.</p>
 <AccountList/>

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor.css
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor.css
@@ -1,6 +1,7 @@
 ﻿.links-container {
     display: flex;
     flex-direction: row;
+    flex-wrap: wrap;
     align-items: center;
     gap: 10px;
     margin-bottom: 10px;

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor.css
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor.css
@@ -1,1 +1,7 @@
-﻿
+﻿.links-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 10px;
+    margin-bottom: 10px;
+}

--- a/WeddingWebsite/Data/Stores/IStore.cs
+++ b/WeddingWebsite/Data/Stores/IStore.cs
@@ -60,4 +60,9 @@ public interface IStore
     /// Get all logs affecting a particular account, regardless of who performed the action.
     /// </summary>
     public IEnumerable<AccountLog> GetAccountLogs(string userId);
+    
+    /// <summary>
+    /// Get all account logs (most recent first).
+    /// </summary>
+    public IEnumerable<AccountLog> GetAllAccountLogs(int limit = 100);
 }

--- a/WeddingWebsite/Data/Stores/Store.cs
+++ b/WeddingWebsite/Data/Stores/Store.cs
@@ -356,4 +356,55 @@ public class Store : IStore
 
         return logs;
     }
+    
+    [Authorize(Roles = "Admin")]
+    public IEnumerable<AccountLog> GetAllAccountLogs(int limit = 100)
+    {
+        using var connection = new SqliteConnection("DataSource=Data\\app.db;Cache=Shared");
+        connection.Open();
+        
+        var command = connection.CreateCommand();
+        command.CommandText =
+            """
+                SELECT log.Timestamp, 
+                       affectedUser.Id, affectedUser.UserName, 
+                       actor.Id, actor.UserName, 
+                       log.EventType, log.Description
+                FROM AccountLog log
+                JOIN AspNetUsers affectedUser ON log.AffectedUserId = affectedUser.Id
+                JOIN AspNetUsers actor ON log.ActorId = actor.Id
+                ORDER BY log.Timestamp DESC
+                LIMIT :limit
+            """;
+        
+        command.Parameters.AddWithValue(":limit", limit);
+        
+        using var reader = command.ExecuteReader();
+        var logs = new List<AccountLog>();
+        while (reader.Read())
+        {
+            var timestampTicks = reader.GetInt64(0);
+            var affectedUserId = reader.GetString(1);
+            var affectedUserName = reader.GetString(2);
+            var actorId = reader.GetString(3);
+            var actorUserName = reader.GetString(4);
+            var eventTypeInt = reader.GetInt16(5);
+            
+            var logType = AccountLogTypeEnumConverter.DatabaseIntegerToAccountLogType(eventTypeInt);
+            
+            var description = reader.IsDBNull(6) ? logType.GetEnumDescription() : reader.GetString(6);
+            
+            var log = new AccountLog(
+                new DateTime(timestampTicks, DateTimeKind.Utc),
+                new Account { Id = affectedUserId, UserName = affectedUserName },
+                new Account { Id = actorId, UserName = actorUserName },
+                logType,
+                description
+            );
+            
+            logs.Add(log);
+        }
+
+        return logs;
+    }
 }

--- a/WeddingWebsite/Services/AdminService.cs
+++ b/WeddingWebsite/Services/AdminService.cs
@@ -47,4 +47,9 @@ public class AdminService(IStore store) : IAdminService
     {
         return store.GetAccountLogs(userId);
     }
+
+    public IEnumerable<AccountLog> GetAllAccountLogs(int limit = 100)
+    {
+        return store.GetAllAccountLogs(limit);
+    }
 }

--- a/WeddingWebsite/Services/IAdminService.cs
+++ b/WeddingWebsite/Services/IAdminService.cs
@@ -13,4 +13,5 @@ public interface IAdminService
     void DeleteGuest(string guestId);
     string? GetAccountIdFromGuestId(string guestId);
     IEnumerable<AccountLog> GetAccountLogs(string userId);
+    IEnumerable<AccountLog> GetAllAccountLogs(int limit = 100);
 }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Adds a new section to the admin page to show recent activity (i.e. account logs, but for any account). This is really handy to have a little nosey and see what's been going on. I also took the chance to make the top bit with register and to-do list a bit more compact.

<img width="824" height="815" alt="image" src="https://github.com/user-attachments/assets/bc20a896-36dc-44d5-9970-c0ae65bc04a0" />

By default, it only shows log in events. However, you can choose which categories you want to view, out of 4 options.

<img width="801" height="521" alt="image" src="https://github.com/user-attachments/assets/3038fa80-6c71-4339-ba0e-ead6bcd8d09f" />

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable

This is an admin-only change. The new layout highlights things that are more important and provides new functionality. It does move the "User Accounts" section to be slightly lower down, however it's not too far to scroll (the recent activity only shows 5 rows per page by default). I think most people would be interested to see recent events at the top before going to the user accounts to do more serious stuff.

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
N/A - admin-only.

## Any interesting design decisions?
Mostly just the layout. I chose to put the recent activity first as it's nice to have at the top and more likely to change therefore more likely that a user would be just glancing at it.

## Does this close any issues?
Closes #110