### PR TITLE
Save registry filters in session storage

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -1,4 +1,5 @@
 ﻿@using System.Security.Claims
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Components.WeddingComponents
 @using WeddingWebsite.Models.ConfigInterfaces
@@ -11,6 +12,7 @@
 @inject IRegistryService RegistryService
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IStringProvider StringProvider
+@inject ProtectedSessionStorage ProtectedSessionStorage
 
 <CascadingValue Value="Config.RegistryConfig.Theme">
     <Section>
@@ -28,7 +30,7 @@
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceLowToHigh">@StringProvider.PriceLowToHigh</MudSelectItem>
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceHighToLow">@StringProvider.PriceHighToLow</MudSelectItem>
                 </MudSelect>
-                <MudSelect T="string" MultiSelection="true" @bind-Value="EnabledFiltersString" @bind-SelectedValues="EnabledFilters" Label="@StringProvider.Filters">
+                <MudSelect T="string" MultiSelection="true" @bind-Value="EnabledFiltersString" @bind-SelectedValues="EnabledFilters" Label="@StringProvider.Filters" OnClose="_ => SaveFilters()">
                     @foreach (var filter in AllFilters)
                     {
                         <MudSelectItem T="string" Value="@filter">@filter</MudSelectItem>
@@ -147,6 +149,16 @@
         }
     }
 
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            EnabledFilters = (await ProtectedSessionStorage.GetAsync<IEnumerable<string>>("RegistryEnabledFilters")).Value ?? new HashSet<string> { "Unclaimed" };
+            EnabledFiltersString = string.Join(",", EnabledFilters);
+            StateHasChanged();
+        }
+    }
+
     private bool ItemMatchesFilter(RegistryItem item)
     {
         if (EnabledFilters.Contains("Unclaimed") && item.IsFullyClaimed)
@@ -204,5 +216,10 @@
             return false;
         }
         return true;
+    }
+    
+    private async Task SaveFilters()
+    {
+        await ProtectedSessionStorage.SetAsync("RegistryEnabledFilters", EnabledFilters);
     }
 }

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -25,7 +25,7 @@
                 <p>@StringProvider.RegistryDescription2</p>
             </div>
             <div class="sort-and-filter-container">
-                <MudSelect T="SortOrder" @bind-Value="CurrentSortOrder" Label="@StringProvider.SortBy">
+                <MudSelect T="SortOrder" Label="@StringProvider.SortBy" Value="CurrentSortOrder" ValueChanged="SortOrderChanged">
                     <MudSelectItem T="SortOrder" Value="SortOrder.Default">@StringProvider.Default</MudSelectItem>
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceLowToHigh">@StringProvider.PriceLowToHigh</MudSelectItem>
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceHighToLow">@StringProvider.PriceHighToLow</MudSelectItem>
@@ -155,6 +155,12 @@
         {
             EnabledFilters = (await ProtectedSessionStorage.GetAsync<IEnumerable<string>>("RegistryEnabledFilters")).Value ?? new HashSet<string> { "Unclaimed" };
             EnabledFiltersString = string.Join(",", EnabledFilters);
+            var sortOrderResult = await ProtectedSessionStorage.GetAsync<int>("RegistrySortOrder");
+            var sortOrderInt = sortOrderResult.Value;
+            if (Enum.IsDefined(typeof(SortOrder), sortOrderInt))
+            {
+                CurrentSortOrder = (SortOrder) sortOrderInt;
+            }
             StateHasChanged();
         }
     }
@@ -221,5 +227,16 @@
     private async Task SaveFilters()
     {
         await ProtectedSessionStorage.SetAsync("RegistryEnabledFilters", EnabledFilters);
+    }
+    
+    private async Task SortOrderChanged(SortOrder newSortOrder)
+    {
+        CurrentSortOrder = newSortOrder;
+        await SaveSortOrder();
+    }
+    
+    private async Task SaveSortOrder()
+    {
+        await ProtectedSessionStorage.SetAsync("RegistrySortOrder", CurrentSortOrder);
     }
 }

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -155,11 +155,10 @@
         {
             EnabledFilters = (await ProtectedSessionStorage.GetAsync<IEnumerable<string>>("RegistryEnabledFilters")).Value ?? new HashSet<string> { "Unclaimed" };
             EnabledFiltersString = string.Join(",", EnabledFilters);
-            var sortOrderResult = await ProtectedSessionStorage.GetAsync<int>("RegistrySortOrder");
-            var sortOrderInt = sortOrderResult.Value;
-            if (Enum.IsDefined(typeof(SortOrder), sortOrderInt))
+            var sortOrderResult = await ProtectedSessionStorage.GetAsync<SortOrder>("RegistrySortOrder");
+            if (sortOrderResult.Success && Enum.IsDefined(typeof(SortOrder), sortOrderResult.Value))
             {
-                CurrentSortOrder = (SortOrder) sortOrderInt;
+                CurrentSortOrder = sortOrderResult.Value;
             }
             StateHasChanged();
         }


### PR DESCRIPTION
## What does this PR do, and why do we need it?
When navigating around the registry, the filters reset each time. This is annoying if you apply a certain filter and navigate into an item and back out again, or refresh the page. It's particularly annoying for admins that will often remove the 'Unclaimed' filter - a contribution towards https://github.com/smileyface12349/wedding-website/issues/122

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable

Remembering the filters within the same browser tab is definitely better than forgetting them each time!

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
N/A

## Any interesting design decisions?
There is a decision between using local storage and session storage. I chose to be conservative and use session storage which applies to the browser tab only as it will be guaranteed to work, but this will not save the configuration if the tab is closed. This means that returning admins will still need to adjust their filters upon first use, but using local storage could cause strange behaviour when using multiple tabs with different filters. This may be changed later, but for now I think we'll stick with session storage and see if it remains annoying or if the issue is fixed.

## Does this close any issues?
https://github.com/smileyface12349/wedding-website/issues/122 suggests having different default filters for admins. As they are now being remembered, this is now less essential and may not be required at all. This should be monitored to see if we still want to adjust the defaults or if remembering it has solved the annoyance completely.
