### PR TITLE
Add email system

### DIFF
--- a/WeddingWebsite/Components/Layouts/SimpleLayout.razor.css
+++ b/WeddingWebsite/Components/Layouts/SimpleLayout.razor.css
@@ -3,6 +3,7 @@
     padding-left: 10px;
     padding-right: 10px;
     margin: 100px auto auto;
+    padding-bottom: 20px;
 }
 
 ::deep .text-center {
@@ -17,9 +18,18 @@
     margin-right: 10px;
 }
 
+::deep .no-margin {
+    margin: 0 !important;
+}
+
 ::deep .flex-container {
     display: flex;
     align-items: center;
+}
+
+::deep .flex-gap {
+    display: flex;
+    gap: 10px;
 }
 
 ::deep .form-input-and-label {
@@ -111,6 +121,10 @@
 
 ::deep .text-red {
     color: red;
+}
+
+::deep .text-success {
+    color: #26b050;
 }
 
 ::deep .flex-center-column {

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor
@@ -15,6 +15,7 @@
     <a href="/account/register" role="button" class="button">Add New Account</a>
     <a href="/todo" role="button" class="button">Go to To-Do List</a>
     <a href="/admin/rsvp/table" role="button" class="button">View RSVP Responses</a>
+    <a href="/admin/email/compose" role="button" class="button">Send Email</a>
 </div>
 
 <h2>Recent Activity</h2>

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -65,9 +65,63 @@
         </div>
         
         <h2>Message</h2>
-        <p>For advanced formatting, please use HTML.</p>
+        <p>For advanced formatting, please use HTML (e.g. &lt;i&gt;italics&lt;/i&gt;, &lt;b&gt;bold&lt;/b&gt;).</p>
+        <p>You can also put in certain variables which will automatically adapt to the recipient so you can give it an extra personal touch. These are all enclosed in % signs.</p>
+        @if (ShowVariables)
+        {
+            <h3>Variables</h3>
+            <table>
+                <tr>
+                    <th>Variable</th>
+                    <th>Example</th>
+                    <th>Notes</th>
+                </tr>
+                @foreach (var variable in EmailVariable.EmailVariables)
+                {
+                    <tr>
+                        <td>%@variable.Pattern%</td>
+                        <td>@variable.Example</td>
+                        <td>@variable.Description</td>
+                    </tr>
+                }
+            </table>
+            <h3>Guest Filters</h3>
+            <p>All patterns that interact with guests have an extra option which is given in brackets. By default,  all guests that match the recipient filters will be shown. For example <code>%NUM_GUESTS(RSVP_WAITING)%</code> will show the number of guests who have not yet submitted an RSVP.</p>
+            <table>
+                <tr>
+                    <th>Filter</th>
+                    <th>Description</th>
+                </tr>
+                <tr>
+                    <td>ALL</td>
+                    <td>All guests on the account.</td>
+                </tr>
+                <tr>
+                    <td>MATCH</td>
+                    <td>Only guests that match the recipient filter (default).</td>
+                </tr>
+                <tr>
+                    <td>RSVP_YES</td>
+                    <td>Only guests that are attending.</td>
+                </tr>
+                <tr>
+                    <td>RSVP_WAITING</td>
+                    <td>Only guests that haven't yet submitted an RSVP.</td>
+                </tr>
+                <tr>
+                    <td>RSVP_NO</td>
+                    <td>Only guests that have declined.</td>
+                </tr>
+            </table>
+            <p><i>Filters are not applied in the test email.</i></p>
+            <Button OnClick="() => { ShowVariables = false; StateHasChanged(); }">Hide Variables</Button>
+        }
+        else
+        {
+            <Button OnClick="() => { ShowVariables = true; StateHasChanged(); }">Show Variables</Button>
+        }
         <div class="form-group">
-            <InputTextArea @bind-Value=Input.Message class="form-control" id="message" placeholder="@MessagePlaceholder" />
+            <InputTextArea @bind-Value=Input.Message class="form-control" style="margin-top: 15px" id="message" placeholder="@MessagePlaceholder" />
         </div>
 
         @if (LoggedInUserEmail == null)
@@ -132,8 +186,8 @@ else
     
     <p>If you are happy with this, please click the button below to send the email to <b>@Recipients.Count()</b> recipients. This action cannot be undone.</p>
     <div class="flex-container flex-gap">
-        <Button OnClickAsync="SendEmail">Send Email</Button>
-        <LinkButton Url="/admin/compose" CssClass="no-margin">Go Back</LinkButton>
+        <Button OnClickAsync="SendEmailToAll">Send Email</Button>
+        <Button OnClick="() => { ReadyToSend = false; StateHasChanged(); }" CssClass="no-margin">Go Back</Button>
     </div>
 }
 
@@ -152,6 +206,7 @@ else
     private string? LoggedInUserEmail { get; set; }
     private IDictionary<string, EmailStatus> Status { get; set; } = new Dictionary<string, EmailStatus>();
     private string ErrorText { get; set; } = "";
+    private bool ShowVariables { get; set; } = false;
 
     private async Task ValidFormSubmitted()
     {
@@ -159,7 +214,7 @@ else
         
         var allAccounts = AdminService.GetAllAccounts().ToList();
         AccountsWithNoEmail = allAccounts.Where(a => a.Email == null).Select(a => a.UserName ?? "No username");
-        AccountsWithEmails = allAccounts.Where(a => a.Email != null).ToDictionary(a => a, a => AccountMatchesFilter(a, Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests) && a.Email != LoggedInUserEmail);
+        AccountsWithEmails = allAccounts.Where(a => a.Email != null).ToDictionary(a => a, a => AccountMatchesFilter(a, new EmailFilters(Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests)) && a.Email != LoggedInUserEmail);
         foreach (var recipient in AccountsWithEmails)
         {
             Status[recipient.Key.Email!] = EmailStatus.NotStarted;
@@ -167,7 +222,13 @@ else
 
         try
         {
-            await EmailSender.SendEmailAsync(LoggedInUserEmail, Input.Subject, Input.Message);
+            var loggedInUser = allAccounts.FirstOrDefault(a => a.Email == LoggedInUserEmail);
+            if (loggedInUser == null)
+            {
+                throw new Exception("Logged in user not found in database.");
+            }
+            // Don't pass in filters and just show all recipients, as it may well not match the logged in user.
+            await SendEmail(loggedInUser, Input.Subject, Input.Message);
             ErrorText = "";
             ReadyToSend = true;
         }
@@ -177,24 +238,34 @@ else
         }
     }
 
-    private async Task SendEmail()
+    private async Task SendEmailToAll()
     {
-        foreach (var recipient in Recipients)
+        foreach (var recipient in AccountsWithEmails.Where(kv => kv.Value).Select(kv => kv.Key))
         {
-            Status[recipient] = EmailStatus.Sending;
+            var email = recipient.Email!;
+            Status[email] = EmailStatus.Sending;
             StateHasChanged();
             try
             {
-                await EmailSender.SendEmailAsync(recipient, Input.Subject, Input.Message);
-                Status[recipient] = EmailStatus.Sent;
+                await SendEmail(recipient, Input.Subject, Input.Message, new EmailFilters(Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests));
+                Status[email] = EmailStatus.Sent;
             }
             catch (Exception e)
             {
-                ErrorText += "Error for " + recipient + ": " + e.Message + "\n";
-                Status[recipient] = EmailStatus.Failed;
+                ErrorText += "Error for " + email + ": " + e.Message + "\n";
+                Status[email] = EmailStatus.Failed;
             }
             StateHasChanged();
         }
+    }
+
+    private async Task SendEmail(AccountWithGuests recipient, string subject, string message, EmailFilters? filters = null)
+    {
+        foreach (var filter in EmailVariable.EmailVariables)
+        {
+            message = filter.Apply(message, recipient, filters ?? new EmailFilters());
+        }
+        await EmailSender.SendEmailAsync(recipient.Email!, subject, message);
     }
 
     protected override async Task OnInitializedAsync()
@@ -226,9 +297,9 @@ else
         public string Message { get; set; } = string.Empty;
     }
 
-    private bool AccountMatchesFilter(AccountWithGuests account, NumGuestsFilter numGuests, RsvpStatusFilter rsvpStatus, bool rsvpStatusMatchAll)
+    private bool AccountMatchesFilter(AccountWithGuests account, EmailFilters filters)
     {
-        switch (numGuests)
+        switch (filters.NumGuestsFilter)
         {
             case NumGuestsFilter.None:
                 if (account.Guests.Count() != 0) return false;
@@ -241,51 +312,27 @@ else
                 break;
         }
 
-        if (!rsvpStatusMatchAll)
+        if (!filters.RsvpStatusMatchAll)
         {
-            switch (rsvpStatus)
-            {
-                case RsvpStatusFilter.NotNo:
-                    if (account.Guests.All(g => g.Rsvp == RsvpStatus.No)) return false;
-                    break;
-                case RsvpStatusFilter.Waiting:
-                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.NotResponded)) return false;
-                    break;
-                case RsvpStatusFilter.Yes:
-                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.Yes)) return false;
-                    break;
-                case RsvpStatusFilter.No:
-                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.No)) return false;
-                    break;
-            }
+            if (!account.Guests.Any(filters.GuestMatchesRsvpStatus)) return false;
         }
         else
         {
-            switch (rsvpStatus)
-            {
-                case RsvpStatusFilter.NotNo:
-                    if (account.Guests.Any(g => g.Rsvp == RsvpStatus.No)) return false;
-                    break;
-                case RsvpStatusFilter.Waiting:
-                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.NotResponded)) return false;
-                    break;
-                case RsvpStatusFilter.Yes:
-                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.Yes)) return false;
-                    break;
-                case RsvpStatusFilter.No:
-                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.No)) return false;
-                    break;
-            }
+            if (account.Guests.Any(g => !filters.GuestMatchesRsvpStatus(g))) return false;
         }
         
         return true;
     }
 
-    private static string MessagePlaceholder => @"Hi %FIRST_NAMES%,
+    private static string MessagePlaceholder => @"Hi %FAMILY_NAME(ALL)%,
                                          
-This is a gentle reminder that the RSVP deadline is in <b>7</b> days. Please ensure you have submitted your RSVP by the deadline. If you have forgotten your password or are having difficulty accessing the website, please reply to this email.
+This is a gentle reminder that the RSVP deadline is in <b>7</b> days. Please ensure you have submitted your RSVP by the deadline. We are still waiting on RSVPs from %FULL_NAMES(RSVP_WAITING)% (%NUM_GUESTS(RSVP_WAITING)%/%NUM_GUESTS%). Please log into the wedding website with the username %USERNAME% to RSVP.
+
+If you have forgotten your password or are having difficulty accessing the website, please reply to this email and we'll get it sorted.
                                          
 Many thanks,
-Bob";
+Bob
+
+<i>This email was sent automatically, but we will receive replies.</i>";
 
 }

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -335,6 +335,7 @@ else
         }
         else
         {
+            if (!account.Guests.Any()) return false; // Don't allow vacuous case.
             if (account.Guests.Any(g => !filters.GuestMatchesRsvpStatus(g))) return false;
         }
         

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -241,7 +241,7 @@ else
     }
     else
     {
-        <p>@Recipients.Count() is a lot of people. Please type "I want to send an email to @Recipients.Count() people" in the box below to confirm this action.</p>
+        <p>@Recipients.Count() is a lot of people. Please type "@CorrectConfirmText" in the box below to confirm this action.</p>
         <InputText @bind-Value=ConfirmText class="confirm-text" placeholder="@CorrectConfirmText" style="width: 250px;margin-bottom: 10px;"/>
         <div class="flex-container flex-gap">
             @if (ConfirmText == CorrectConfirmText)

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -331,7 +331,7 @@ else
 
         if (!filters.RsvpStatusMatchAll)
         {
-            if (!account.Guests.Any(filters.GuestMatchesRsvpStatus)) return false;
+            if (filters.RsvpStatusFilter != RsvpStatusFilter.Any && !account.Guests.Any(filters.GuestMatchesRsvpStatus)) return false;
         }
         else
         {

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -1,0 +1,291 @@
+﻿@page "/Admin/Email/Compose"
+
+@using System.ComponentModel.DataAnnotations
+@using System.Security.Claims
+@using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Core.Emails
+@using WeddingWebsite.Data.Models
+@using WeddingWebsite.Models.Accounts
+@using WeddingWebsite.Models.Emails
+@using WeddingWebsite.Services
+@using WeddingWebsite.Components.Elements
+
+@inject IEmailSender EmailSender
+@inject IAdminService AdminService
+@inject AuthenticationStateProvider AuthenticationStateProvider
+
+@attribute [Authorize(Roles = "Admin")]
+
+@layout SimpleLayout
+
+<PageTitle>Compose Email</PageTitle>
+
+@if (!ReadyToSend)
+{
+    <EditForm Model=@Input OnValidSubmit=@ValidFormSubmitted>
+        <DataAnnotationsValidator />
+        <h1>Compose Email</h1>
+        <p>Send an email to lots of guests at once. Nothing will be sent until you review it and confirm it.</p>
+        <ValidationSummary class="text-danger" />
+        <h2>Filters</h2>
+        <div class="form-group">
+            <label for="num-guests">Number of Guests</label>
+            <MudRadioGroup T="NumGuestsFilter" @bind-Value="Input.NumGuestsFilter" id="num-guests">
+                <MudRadio Value="NumGuestsFilter.Any">Any Number</MudRadio>
+                <MudRadio Value="NumGuestsFilter.None">None</MudRadio>
+                <MudRadio Value="NumGuestsFilter.One">One</MudRadio>
+                <MudRadio Value="NumGuestsFilter.Multiple">More Than One</MudRadio>
+            </MudRadioGroup>
+        </div>
+        
+        <div class="form-group">
+            <label for="rsvp-status">RSVP Status</label>
+            <MudRadioGroup T="RsvpStatusFilter" @bind-Value="Input.RsvpStatusFilter" id="rsvp-status">
+                <MudRadio Value="RsvpStatusFilter.Any">Any</MudRadio>
+                <MudRadio Value="RsvpStatusFilter.NotNo">Not No</MudRadio>
+                <MudRadio Value="RsvpStatusFilter.Waiting">Waiting</MudRadio>
+                <MudRadio Value="RsvpStatusFilter.Yes">Yes</MudRadio>
+                <MudRadio Value="RsvpStatusFilter.No">No</MudRadio>
+            </MudRadioGroup>
+        </div>
+        
+        @if (Input.RsvpStatusFilter != RsvpStatusFilter.Any && Input.NumGuestsFilter != NumGuestsFilter.None && Input.NumGuestsFilter != NumGuestsFilter.One)
+        {
+            <p>For accounts with multiple guests, please choose whether you want to send an email if <i>every</i> guest on the account has this RSVP status, or merely if <i>at least one</i> does.</p>
+            <div class="form-group">
+                <label for="match-all-guests">Require a match on every guest</label>
+                <InputCheckbox @bind-Value=Input.RsvpMatchAllGuests id="match-all-guests" />
+            </div>
+        }
+        
+        <h2>Subject</h2>
+        <div class="form-group">
+            <label for="subject">Subject</label>
+            <InputText @bind-Value=Input.Subject class="form-control" id="subject" placeholder="RSVP Deadline Reminder" />
+        </div>
+        
+        <h2>Message</h2>
+        <p>For advanced formatting, please use HTML.</p>
+        <div class="form-group">
+            <InputTextArea @bind-Value=Input.Message class="form-control" id="message" placeholder="@MessagePlaceholder" />
+        </div>
+
+        @if (LoggedInUserEmail == null)
+        {
+            <p class="text-danger">You do not have an email address on your account. This is required to send a test email. You will not be able to use this feature until you have added an email address to your account.</p>
+        }
+        else
+        {
+            <p>This will send a test email to @LoggedInUserEmail and generate a list of recipients for you to check.</p>
+            <input type="submit" class="button" value="Send Test Email & Review" style="cursor: pointer" />
+        }
+
+    </EditForm>
+}
+else if (Status.Values.Any(v => v != EmailStatus.NotStarted))
+{
+    <h2>Sending</h2>
+    <p>Your emails are being sent. It is not possible to cancel this operation.</p>
+    <ul style="margin-left: 20px; margin-bottom: 10px;">
+        @foreach (var recipient in Recipients)
+        {
+            @switch (Status[recipient])
+            {
+                case EmailStatus.NotStarted:
+                    <li>@recipient</li>
+                    break;
+                case EmailStatus.Sending:
+                    <li>@recipient - Sending...</li>
+                    break;
+                case EmailStatus.Sent:
+                    <li>@recipient - <span class="text-success">Sent</span></li>
+                    break;
+                case EmailStatus.Failed:
+                    <li>@recipient - <span class="text-danger">Failed</span></li>
+                    break;
+            }
+        }
+    </ul>
+    @if (AccountsWithEmails.Keys.Where(a => AccountsWithEmails[a]).Select(a => a.Email!).All(recipient => Status[recipient] is EmailStatus.Sent or EmailStatus.Failed))
+    {
+        <LinkButton Url="/admin">Back to Admin Page</LinkButton>
+    }
+}
+else
+{
+    <h1>Review & Send</h1>
+    <p>A test email was sent to @LoggedInUserEmail. Please go to your email and check that it displays how you expect it to. A preview is also shown below:</p>
+    <p><i>Subject: @Input.Subject</i></p>
+    <div class="email-preview">@((MarkupString)Input.Message)</div>
+    <p>You are about to send this email to @Recipients.Count() people. Please carefully review the list of recipients:</p>
+    @foreach (var account in AccountsWithEmails.Keys)
+    {
+        <div class="form-group">
+            <MudCheckBox Value="AccountsWithEmails[account]" ValueChanged="(bool val) => AccountsWithEmails[account] = val" Label="@(account.Email ?? "No Email")"></MudCheckBox>
+        </div>
+    }
+    
+    @if (AccountsWithNoEmail.Any())
+    {
+        <p class="text-danger">You have @(AccountsWithNoEmail.Count()) accounts that do not have an email address: @string.Join(", ", AccountsWithNoEmail).</p>
+    }
+    
+    <p>If you are happy with this, please click the button below to send the email to <b>@Recipients.Count()</b> recipients. This action cannot be undone.</p>
+    <div class="flex-container flex-gap">
+        <Button OnClickAsync="SendEmail">Send Email</Button>
+        <LinkButton Url="/admin/compose" CssClass="no-margin">Go Back</LinkButton>
+    </div>
+}
+
+@if (ErrorText != "")
+{
+    <p class="text-danger">@ErrorText</p>
+}
+
+@code {
+
+    private InputModel Input { get; set; } = new();
+    private IDictionary<AccountWithGuests, bool> AccountsWithEmails { get; set; } = new Dictionary<AccountWithGuests, bool>();
+    private IEnumerable<string> Recipients => AccountsWithEmails.Where(kv => kv.Value).Select(kv => kv.Key.Email!);
+    private IEnumerable<string> AccountsWithNoEmail { get; set; } = [];
+    private bool ReadyToSend { get; set; } = false;
+    private string? LoggedInUserEmail { get; set; }
+    private IDictionary<string, EmailStatus> Status { get; set; } = new Dictionary<string, EmailStatus>();
+    private string ErrorText { get; set; } = "";
+
+    private async Task ValidFormSubmitted()
+    {
+        if (LoggedInUserEmail == null) return;
+        
+        var allAccounts = AdminService.GetAllAccounts().ToList();
+        AccountsWithNoEmail = allAccounts.Where(a => a.Email == null).Select(a => a.UserName ?? "No username");
+        AccountsWithEmails = allAccounts.Where(a => a.Email != null).ToDictionary(a => a, a => AccountMatchesFilter(a, Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests) && a.Email != LoggedInUserEmail);
+        foreach (var recipient in AccountsWithEmails)
+        {
+            Status[recipient.Key.Email!] = EmailStatus.NotStarted;
+        }
+
+        try
+        {
+            await EmailSender.SendEmailAsync(LoggedInUserEmail, Input.Subject, Input.Message);
+            ErrorText = "";
+            ReadyToSend = true;
+        }
+        catch (Exception e)
+        {
+            ErrorText = "Failed to send test email. Error details: " + e.Message;
+        }
+    }
+
+    private async Task SendEmail()
+    {
+        foreach (var recipient in Recipients)
+        {
+            Status[recipient] = EmailStatus.Sending;
+            StateHasChanged();
+            try
+            {
+                await EmailSender.SendEmailAsync(recipient, Input.Subject, Input.Message);
+                Status[recipient] = EmailStatus.Sent;
+            }
+            catch (Exception e)
+            {
+                ErrorText += "Error for " + recipient + ": " + e.Message + "\n";
+                Status[recipient] = EmailStatus.Failed;
+            }
+            StateHasChanged();
+        }
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
+        var user = authState.User;
+        if (user.Identity != null && user.Identity.IsAuthenticated)
+        {
+            var emailClaim = user.FindFirst(ClaimTypes.Email);
+            LoggedInUserEmail = emailClaim?.Value;
+        }
+    }
+
+    private class InputModel 
+    {
+        [Required]
+        public NumGuestsFilter NumGuestsFilter { get; set; } = NumGuestsFilter.Any;
+        
+        [Required]
+        public RsvpStatusFilter RsvpStatusFilter { get; set; } = RsvpStatusFilter.Any;
+
+        [Required]
+        public bool RsvpMatchAllGuests { get; set; } = false;
+
+        [Required]
+        public string Subject { get; set; } = string.Empty;
+
+        [Required]
+        public string Message { get; set; } = string.Empty;
+    }
+
+    private bool AccountMatchesFilter(AccountWithGuests account, NumGuestsFilter numGuests, RsvpStatusFilter rsvpStatus, bool rsvpStatusMatchAll)
+    {
+        switch (numGuests)
+        {
+            case NumGuestsFilter.None:
+                if (account.Guests.Count() != 0) return false;
+                break;
+            case NumGuestsFilter.One:
+                if (account.Guests.Count() != 1) return false;
+                break;
+            case NumGuestsFilter.Multiple:
+                if (account.Guests.Count() <= 1) return false;
+                break;
+        }
+
+        if (!rsvpStatusMatchAll)
+        {
+            switch (rsvpStatus)
+            {
+                case RsvpStatusFilter.NotNo:
+                    if (account.Guests.All(g => g.Rsvp == RsvpStatus.No)) return false;
+                    break;
+                case RsvpStatusFilter.Waiting:
+                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.NotResponded)) return false;
+                    break;
+                case RsvpStatusFilter.Yes:
+                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.Yes)) return false;
+                    break;
+                case RsvpStatusFilter.No:
+                    if (account.Guests.All(g => g.Rsvp != RsvpStatus.No)) return false;
+                    break;
+            }
+        }
+        else
+        {
+            switch (rsvpStatus)
+            {
+                case RsvpStatusFilter.NotNo:
+                    if (account.Guests.Any(g => g.Rsvp == RsvpStatus.No)) return false;
+                    break;
+                case RsvpStatusFilter.Waiting:
+                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.NotResponded)) return false;
+                    break;
+                case RsvpStatusFilter.Yes:
+                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.Yes)) return false;
+                    break;
+                case RsvpStatusFilter.No:
+                    if (account.Guests.Any(g => g.Rsvp != RsvpStatus.No)) return false;
+                    break;
+            }
+        }
+        
+        return true;
+    }
+
+    private static string MessagePlaceholder => @"Hi %FIRST_NAMES%,
+                                         
+This is a gentle reminder that the RSVP deadline is in <b>7</b> days. Please ensure you have submitted your RSVP by the deadline. If you have forgotten your password or are having difficulty accessing the website, please reply to this email.
+                                         
+Many thanks,
+Bob";
+
+}

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -207,7 +207,7 @@ else
 
 @if (ErrorText != "")
 {
-    <p class="text-danger">@ErrorText</p>
+    <p class="text-danger" style="white-space: pre-wrap;">@ErrorText</p>
 }
 
 @code {

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -270,6 +270,8 @@ else
         var allAccounts = AdminService.GetAllAccounts().ToList();
         AccountsWithNoEmail = allAccounts.Where(a => a.Email == null).Select(a => a.UserName ?? "No username");
         AccountsWithEmails = allAccounts.Where(a => a.Email != null).ToDictionary(a => a, a => AccountMatchesFilter(a, new EmailFilters(Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests)) && a.Email != LoggedInUserEmail);
+        // Order the checkboxes so that the ones matching the filters are at the top
+        AccountsWithEmails = AccountsWithEmails.OrderByDescending(kv => kv.Value).ToDictionary(kv => kv.Key, kv => kv.Value);
         foreach (var recipient in AccountsWithEmails)
         {
             Status[recipient.Key.Email!] = EmailStatus.NotStarted;

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -155,6 +155,7 @@ else if (Status.Values.Any(v => v != EmailStatus.NotStarted))
     else
     {
         <p>Your emails are being sent. To stop this, press "Pause" at the bottom. Depending on your email provider, you may want to use the pause button to slow down the delivery and avoid exceeding rate limits or having emails sent to spam.</p>
+        <p>You should keep this tab open until all emails are delivered. If it is closed, the remaining emails may or may not get delivered and there will be no way to pause it.</p>
     }
     <ul style="margin-left: 20px; margin-bottom: 10px;">
         @foreach (var recipient in Recipients)

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -189,7 +189,7 @@ else
     @foreach (var account in AccountsWithEmails.Keys)
     {
         <div class="form-group">
-            <MudCheckBox Value="AccountsWithEmails[account]" ValueChanged="(bool val) => AccountsWithEmails[account] = val" Label="@(account.Email ?? "No Email")"></MudCheckBox>
+            <MudCheckBox Value="AccountsWithEmails[account]" ValueChanged="(bool val) => { AccountsWithEmails[account] = val; SendEmailPressed = false; }" Label="@(account.Email ?? "No Email")"></MudCheckBox>
         </div>
     }
     
@@ -199,10 +199,25 @@ else
     }
     
     <p>If you are happy with this, please click the button below to send the email to <b>@Recipients.Count()</b> recipients. This action cannot be undone.</p>
-    <div class="flex-container flex-gap">
-        <Button OnClickAsync="SendEmailToAll">Send Email</Button>
-        <Button OnClick="() => { ReadyToSend = false; StateHasChanged(); }" CssClass="no-margin">Go Back</Button>
-    </div>
+    @if (!SendEmailPressed)
+    {
+        <div class="flex-container flex-gap">
+            <Button OnClickAsync="SendEmailFirstPress">Send Email</Button>
+            <Button OnClick="() => { ReadyToSend = false; StateHasChanged(); }" CssClass="no-margin">Go Back</Button>
+        </div>
+    }
+    else
+    {
+        <p>@Recipients.Count() is a lot of people. Please type "I want to send an email to @Recipients.Count() people" in the box below to confirm this action.</p>
+        <InputText @bind-Value=ConfirmText class="confirm-text" placeholder="@CorrectConfirmText" style="width: 250px;margin-bottom: 10px;"/>
+        <div class="flex-container flex-gap">
+            @if (ConfirmText == CorrectConfirmText)
+            {
+                <Button OnClickAsync="SendEmailToAll">Send Email</Button>
+            }
+            <Button OnClick="() => { ReadyToSend = false; StateHasChanged(); }" CssClass="no-margin">Go Back</Button>
+        </div>
+    }
 }
 
 @if (ErrorText != "")
@@ -221,6 +236,9 @@ else
     private IDictionary<string, EmailStatus> Status { get; set; } = new Dictionary<string, EmailStatus>();
     private string ErrorText { get; set; } = "";
     private bool ShowVariables { get; set; } = false;
+    private string ConfirmText { get; set; } = "";
+    private bool SendEmailPressed { get; set; } = false;
+    private string CorrectConfirmText => $"I want to send an email to {Recipients.Count()} people";
 
     private async Task ValidFormSubmitted()
     {
@@ -249,6 +267,20 @@ else
         catch (Exception e)
         {
             ErrorText = "Failed to send test email. Error details: " + e.Message;
+        }
+    }
+    
+    private async Task SendEmailFirstPress()
+    {
+        if (Recipients.Count() < 10)
+        {
+            await SendEmailToAll();
+        }
+        else
+        {
+            SendEmailPressed = true;
+            ConfirmText = "";
+            StateHasChanged();
         }
     }
 

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -2,6 +2,8 @@
 
 @using System.ComponentModel.DataAnnotations
 @using System.Security.Claims
+@using System.Text.RegularExpressions
+@using System.Web
 @using WeddingWebsite.Components.Layouts
 @using WeddingWebsite.Core.Emails
 @using WeddingWebsite.Data.Models
@@ -65,7 +67,11 @@
         </div>
         
         <h2>Message</h2>
-        <p>For advanced formatting, please use HTML (e.g. &lt;i&gt;italics&lt;/i&gt;, &lt;b&gt;bold&lt;/b&gt;).</p>
+        <p>Advanced formatting including images is possible through HTML (e.g. &lt;i&gt;italics&lt;/i&gt;, &lt;b&gt;bold&lt;/b&gt;). If enabled, you will need to use &lt;br&gt; for new lines.</p>
+        <div class="form-group">
+            <label for="use-html">Use HTML</label>
+            <InputCheckbox @bind-Value=Input.UseHtml id="use-html" />
+        </div>
         <p>You can also put in certain variables which will automatically adapt to the recipient so you can give it an extra personal touch. These are all enclosed in % signs.</p>
         @if (ShowVariables)
         {
@@ -170,7 +176,16 @@ else
     <h1>Review & Send</h1>
     <p>A test email was sent to @LoggedInUserEmail. Please go to your email and check that it displays how you expect it to. A preview is also shown below:</p>
     <p><i>Subject: @Input.Subject</i></p>
-    <div class="email-preview">@((MarkupString)Input.Message)</div>
+    @if (Input.UseHtml)
+    {
+        <div class="email-preview">@((MarkupString)Input.Message)</div>
+    }
+    else
+    {
+        // This is required to preserve new lines, and not render any HTML.
+        <div class="email-preview">@((MarkupString)Regex.Replace(
+                                       HttpUtility.HtmlEncode(Input.Message), "\r?\n|\r", "<br>"))</div>
+    }
     <p>You are about to send this email to @Recipients.Count() people. Please carefully review the list of recipients:</p>
     @foreach (var account in AccountsWithEmails.Keys)
     {
@@ -265,7 +280,7 @@ else
         {
             message = filter.Apply(message, recipient, filters ?? new EmailFilters());
         }
-        await EmailSender.SendEmailAsync(recipient.Email!, subject, message);
+        await EmailSender.SendEmailAsync(recipient.Email!, subject, message, Input.UseHtml);
     }
 
     protected override async Task OnInitializedAsync()
@@ -295,6 +310,9 @@ else
 
         [Required]
         public string Message { get; set; } = string.Empty;
+
+        [Required]
+        public bool UseHtml { get; set; } = false;
     }
 
     private bool AccountMatchesFilter(AccountWithGuests account, EmailFilters filters)
@@ -324,15 +342,25 @@ else
         return true;
     }
 
-    private static string MessagePlaceholder => @"Hi %FAMILY_NAME(ALL)%,
+    private string MessagePlaceholder => Input.UseHtml ? @"Hi %FAMILY_NAME(ALL)%,
+<br>
+<br>This is a gentle reminder that the RSVP deadline is in <b>7</b> days. Please ensure you have submitted your RSVP by the deadline. We are still waiting on RSVPs from %FULL_NAMES(RSVP_WAITING)% (%NUM_GUESTS(RSVP_WAITING)%/%NUM_GUESTS%). Please log into the wedding website with the username %USERNAME% to RSVP.
+<br>
+<br>If you have forgotten your password or are having difficulty accessing the website, please reply to this email and we'll get it sorted.
+<br>           
+<br>Many thanks,
+<br>Bob
+<br>
+<br><i>This email was sent automatically, but we will receive replies.</i>
+" : @"Hi %FAMILY_NAME(ALL)%,
                                          
-This is a gentle reminder that the RSVP deadline is in <b>7</b> days. Please ensure you have submitted your RSVP by the deadline. We are still waiting on RSVPs from %FULL_NAMES(RSVP_WAITING)% (%NUM_GUESTS(RSVP_WAITING)%/%NUM_GUESTS%). Please log into the wedding website with the username %USERNAME% to RSVP.
+This is a gentle reminder that the RSVP deadline is in 7 days. Please ensure you have submitted your RSVP by the deadline. We are still waiting on RSVPs from %FULL_NAMES(RSVP_WAITING)% (%NUM_GUESTS(RSVP_WAITING)%/%NUM_GUESTS%). Please log into the wedding website with the username %USERNAME% to RSVP.
 
 If you have forgotten your password or are having difficulty accessing the website, please reply to this email and we'll get it sorted.
                                          
 Many thanks,
 Bob
 
-<i>This email was sent automatically, but we will receive replies.</i>";
+(This email was sent automatically, but we will receive replies).";
 
 }

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -1,13 +1,12 @@
 ﻿@page "/Admin/Email/Compose"
 
 @using System.ComponentModel.DataAnnotations
+@using System.Net
 @using System.Security.Claims
 @using System.Text.RegularExpressions
-@using System.Web
 @using WeddingWebsite.Components.Layouts
 @using WeddingWebsite.Core.Emails
 @using WeddingWebsite.Data.Models
-@using WeddingWebsite.Models.Accounts
 @using WeddingWebsite.Models.Emails
 @using WeddingWebsite.Services
 @using WeddingWebsite.Components.Elements
@@ -184,7 +183,7 @@ else
     {
         // This is required to preserve new lines, and not render any HTML.
         <div class="email-preview">@((MarkupString)Regex.Replace(
-                                       HttpUtility.HtmlEncode(Input.Message), "\r?\n|\r", "<br>"))</div>
+                                       WebUtility.HtmlEncode(Input.Message), "\r?\n|\r", "<br>"))</div>
     }
     <p>You are about to send this email to @Recipients.Count() people. Please carefully review the list of recipients:</p>
     @foreach (var account in AccountsWithEmails.Keys)

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -144,7 +144,18 @@
 else if (Status.Values.Any(v => v != EmailStatus.NotStarted))
 {
     <h2>Sending</h2>
-    <p>Your emails are being sent. It is not possible to cancel this operation.</p>
+    @if (AccountsWithEmails.Keys.Where(a => AccountsWithEmails[a]).Select(a => a.Email!).All(recipient => Status[recipient] is EmailStatus.Sent or EmailStatus.Failed))
+    {
+        <p>Your emails have been sent. It is not possible to undo this action.</p>
+    }
+    else if (IsSendingPaused)
+    {
+        <p>Email delivery is currently paused. Press "Resume" to resume. If you close this tab, your progress will not be saved.</p>
+    }
+    else
+    {
+        <p>Your emails are being sent. To stop this, press "Pause" at the bottom. Depending on your email provider, you may want to use the pause button to slow down the delivery and avoid exceeding rate limits or having emails sent to spam.</p>
+    }
     <ul style="margin-left: 20px; margin-bottom: 10px;">
         @foreach (var recipient in Recipients)
         {
@@ -168,6 +179,17 @@ else if (Status.Values.Any(v => v != EmailStatus.NotStarted))
     @if (AccountsWithEmails.Keys.Where(a => AccountsWithEmails[a]).Select(a => a.Email!).All(recipient => Status[recipient] is EmailStatus.Sent or EmailStatus.Failed))
     {
         <LinkButton Url="/admin">Back to Admin Page</LinkButton>
+    }
+    else
+    {
+        if (IsSendingPaused)
+        {
+            <Button OnClick="() => { IsSendingPaused = false; StateHasChanged(); }">Resume</Button>
+        }
+        else
+        {
+            <Button OnClick="() => { IsSendingPaused = true; StateHasChanged(); }">Pause</Button>
+        }
     }
 }
 else
@@ -239,6 +261,7 @@ else
     private string ConfirmText { get; set; } = "";
     private bool SendEmailPressed { get; set; } = false;
     private string CorrectConfirmText => $"I want to send an email to {Recipients.Count()} people";
+    private bool IsSendingPaused { get; set; } = false;
 
     private async Task ValidFormSubmitted()
     {
@@ -288,6 +311,11 @@ else
     {
         foreach (var recipient in AccountsWithEmails.Where(kv => kv.Value).Select(kv => kv.Key))
         {
+            while (IsSendingPaused)
+            {
+                await Task.Delay(500);
+            }
+
             var email = recipient.Email!;
             Status[email] = EmailStatus.Sending;
             StateHasChanged();
@@ -300,6 +328,7 @@ else
             {
                 ErrorText += "Error for " + email + ": " + e.Message + "\n";
                 Status[email] = EmailStatus.Failed;
+                IsSendingPaused = true;
             }
             StateHasChanged();
         }

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -173,6 +173,9 @@ else if (Status.Values.Any(v => v != EmailStatus.NotStarted))
                 case EmailStatus.Failed:
                     <li>@recipient - <span class="text-danger">Failed</span></li>
                     break;
+                case EmailStatus.Waiting:
+                    <li>@recipient - Waiting for @EmailDelayInSeconds seconds before sending...</li>
+                    break;
             }
         }
     </ul>
@@ -220,7 +223,14 @@ else
         <p class="text-danger">You have @(AccountsWithNoEmail.Count()) accounts that do not have an email address: @string.Join(", ", AccountsWithNoEmail).</p>
     }
     
-    <p>If you are happy with this, please click the button below to send the email to <b>@Recipients.Count()</b> recipients. This action cannot be undone.</p>
+    <p>You may want to introduce a delay between each email to avoid ending up on your email provider's naughty list. You can also press pause later while they are sending.</p>
+    <div class="form-group">
+        <label for="email-delay">Delay</label>
+        <InputNumber @bind-Value=EmailDelayInSeconds id="email-delay" class="form-control" style="width: 70px"/>
+        <p>seconds</p>
+    </div>
+    
+    <p>If you are happy with this, please click the button below to send the email to @Recipients.Count() recipients. This action cannot be undone.</p>
     @if (!SendEmailPressed)
     {
         <div class="flex-container flex-gap">
@@ -262,6 +272,7 @@ else
     private bool SendEmailPressed { get; set; } = false;
     private string CorrectConfirmText => $"I want to send an email to {Recipients.Count()} people";
     private bool IsSendingPaused { get; set; } = false;
+    private int EmailDelayInSeconds { get; set; } = 0;
 
     private async Task ValidFormSubmitted()
     {
@@ -319,8 +330,21 @@ else
             }
 
             var email = recipient.Email!;
+            
+            Status[email] = EmailStatus.Waiting;
+            StateHasChanged();
+            await Task.Delay(EmailDelayInSeconds * 1000);
+            Status[email] = EmailStatus.NotStarted;
+            StateHasChanged();
+            
+            while (IsSendingPaused)
+            {
+                await Task.Delay(500);
+            }
+
             Status[email] = EmailStatus.Sending;
             StateHasChanged();
+            
             try
             {
                 await SendEmail(recipient, Input.Subject, Input.Message, new EmailFilters(Input.NumGuestsFilter, Input.RsvpStatusFilter, Input.RsvpMatchAllGuests));

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor.css
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor.css
@@ -1,0 +1,28 @@
+﻿.form-group ::deep p, .form-group ::deep label {
+    margin: 0;
+}
+
+::deep #message {
+    height: 400px;
+    resize: none;
+    overflow-y: scroll;
+    width: 100%;
+}
+
+.form-group {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 15px;
+    margin-bottom: 10px;
+}
+
+.email-preview {
+    padding: 10px;
+    border: 1px solid #000;
+    margin-bottom: 10px;
+}
+
+::deep .mud-input-control ::deep p, ::deep .mud-input-control ::deep label {
+    margin: 0 !important;
+}

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor.css
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor.css
@@ -26,3 +26,19 @@
 ::deep .mud-input-control ::deep p, ::deep .mud-input-control ::deep label {
     margin: 0 !important;
 }
+
+td {
+    padding-right: 1vw;
+}
+
+h3 {
+    margin-top: 10px;
+}
+
+th {
+    text-align: left;
+}
+
+table {
+    margin-bottom: 10px;
+}

--- a/WeddingWebsite/Config/Credentials/NoCredentials.cs
+++ b/WeddingWebsite/Config/Credentials/NoCredentials.cs
@@ -1,4 +1,5 @@
-﻿using WeddingWebsite.Models.ConfigInterfaces;
+﻿using WeddingWebsite.Core.Emails;
+using WeddingWebsite.Models.ConfigInterfaces;
 
 namespace WeddingWebsite.Config.Credentials;
 
@@ -10,4 +11,5 @@ namespace WeddingWebsite.Config.Credentials;
 public class NoCredentials : ICredentials
 {
     public string GoogleMaps => "";
+    public EmailConfiguration EmailConfiguration => new EmailConfiguration();
 }

--- a/WeddingWebsite/Core/Emails/EmailConfiguration.cs
+++ b/WeddingWebsite/Core/Emails/EmailConfiguration.cs
@@ -1,0 +1,12 @@
+﻿namespace WeddingWebsite.Core.Emails;
+
+public class EmailConfiguration
+{
+    public string Host { get; set; } = string.Empty;
+    public int Port { get; set; }
+    public string Username { get; set; } = string.Empty;
+    public string Password { get; set; } = string.Empty;
+    public string From { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public bool EnableSSL { get; set; } = true;
+}

--- a/WeddingWebsite/Core/Emails/EmailMessage.cs
+++ b/WeddingWebsite/Core/Emails/EmailMessage.cs
@@ -1,0 +1,15 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace WeddingWebsite.Core.Emails;
+
+public class EmailMessage
+{
+    [EmailAddress]
+    public string Recipient { get; set; } = string.Empty;
+
+    [Required]
+    public string Subject { get; set; } = string.Empty;
+
+    [Required]
+    public string Message { get; set; } = string.Empty;
+}

--- a/WeddingWebsite/Core/Emails/IEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/IEmailSender.cs
@@ -2,5 +2,8 @@
 
 public interface IEmailSender
 {
-    Task SendEmailAsync(string email, string subject, string htmlMessage);
+    /// <summary>
+    /// Sends an email. The message can be either HTML or plaintext.
+    /// </summary>
+    Task SendEmailAsync(string email, string subject, string message, bool isHtml = false);
 }

--- a/WeddingWebsite/Core/Emails/IEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/IEmailSender.cs
@@ -1,0 +1,6 @@
+﻿namespace WeddingWebsite.Core.Emails;
+
+public interface IEmailSender
+{
+    Task SendEmailAsync(string email, string subject, string htmlMessage);
+}

--- a/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
@@ -6,48 +6,29 @@ using WeddingWebsite.Models.ConfigInterfaces;
 
 namespace WeddingWebsite.Core.Emails;
 
-public class MailKitEmailSender : IEmailSender
+public class MailKitEmailSender(ICredentials credentials) : IEmailSender
 {
-    private readonly EmailConfiguration _emailConfiguration;
+    private readonly EmailConfiguration config = credentials.EmailConfiguration;
 
-    public MailKitEmailSender(ICredentials credentials)
+    public async Task SendEmailAsync(string recipient, string subject, string message, bool isHtml = false)
     {
-        _emailConfiguration = credentials.EmailConfiguration;
-    }
-
-    public Task SendEmailAsync(string email, string subject, string htmlMessage)
-    {
-        return Execute(email, subject, htmlMessage);
-    }
-
-    private async Task Execute(string to, string subject, string htmlMessage)
-    {
-        string host = _emailConfiguration.Host;
-        int port = _emailConfiguration.Port;
-        string username = _emailConfiguration.Username;
-        string password = _emailConfiguration.Password;
-        string from = _emailConfiguration.From;
-        string name = _emailConfiguration.Name;
-        bool enableSsl = _emailConfiguration.EnableSSL;
-
         var email = new MimeMessage();
 
-        var sender = MailboxAddress.Parse(from);
-        if (!string.IsNullOrEmpty(name))
-            sender.Name = name;
+        var sender = MailboxAddress.Parse(config.From);
+        if (!string.IsNullOrEmpty(config.Name))
+            sender.Name = config.Name;
         email.Sender = sender;
         email.From.Add(sender);
-        email.To.Add(MailboxAddress.Parse(to));
+        email.To.Add(MailboxAddress.Parse(recipient));
         email.Subject = subject;
-        email.Body = new TextPart(TextFormat.Html) { Text = htmlMessage };
+        email.Body = new TextPart(isHtml ? TextFormat.Html : TextFormat.Text) { Text = message };
 
         using var smtp = new SmtpClient();
         smtp.Timeout = 10000;
-        await smtp.ConnectAsync(host, port, enableSsl);
-        if (!string.IsNullOrEmpty(username))
-            smtp.Authenticate(username, password);
+        await smtp.ConnectAsync(config.Host, config.Port, config.EnableSSL);
+        if (!string.IsNullOrEmpty(config.Username))
+            await smtp.AuthenticateAsync(config.Username, config.Password);
         await smtp.SendAsync(email);
         await smtp.DisconnectAsync(true);
-
     }
 }

--- a/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
@@ -12,6 +12,9 @@ public class MailKitEmailSender(ICredentials credentials) : IEmailSender
 
     public async Task SendEmailAsync(string recipient, string subject, string message, bool isHtml = false)
     {
+        if (string.IsNullOrEmpty(config.Host) || config.Port == 0)
+            throw new InvalidOperationException("Please fill in the email credentials to send emails.");
+        
         var email = new MimeMessage();
 
         var sender = MailboxAddress.Parse(config.From);

--- a/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
@@ -1,0 +1,53 @@
+﻿using MailKit.Net.Smtp;
+using Microsoft.Extensions.Options;
+using MimeKit;
+using MimeKit.Text;
+using WeddingWebsite.Models.ConfigInterfaces;
+
+namespace WeddingWebsite.Core.Emails;
+
+public class MailKitEmailSender : IEmailSender
+{
+    private readonly EmailConfiguration _emailConfiguration;
+
+    public MailKitEmailSender(ICredentials credentials)
+    {
+        _emailConfiguration = credentials.EmailConfiguration;
+    }
+
+    public Task SendEmailAsync(string email, string subject, string htmlMessage)
+    {
+        return Execute(email, subject, htmlMessage);
+    }
+
+    private async Task Execute(string to, string subject, string htmlMessage)
+    {
+        string host = _emailConfiguration.Host;
+        int port = _emailConfiguration.Port;
+        string username = _emailConfiguration.Username;
+        string password = _emailConfiguration.Password;
+        string from = _emailConfiguration.From;
+        string name = _emailConfiguration.Name;
+        bool enableSsl = _emailConfiguration.EnableSSL;
+
+        var email = new MimeMessage();
+
+        var sender = MailboxAddress.Parse(from);
+        if (!string.IsNullOrEmpty(name))
+            sender.Name = name;
+        email.Sender = sender;
+        email.From.Add(sender);
+        email.To.Add(MailboxAddress.Parse(to));
+        email.Subject = subject;
+        email.Body = new TextPart(TextFormat.Html) { Text = htmlMessage };
+
+        using var smtp = new SmtpClient();
+        smtp.Timeout = 10000;
+        await smtp.ConnectAsync(host, port, enableSsl);
+        if (!string.IsNullOrEmpty(username))
+            smtp.Authenticate(username, password);
+        await smtp.SendAsync(email);
+        await smtp.DisconnectAsync(true);
+
+    }
+}

--- a/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
+++ b/WeddingWebsite/Core/Emails/MailKitEmailSender.cs
@@ -1,5 +1,4 @@
 ﻿using MailKit.Net.Smtp;
-using Microsoft.Extensions.Options;
 using MimeKit;
 using MimeKit.Text;
 using WeddingWebsite.Models.ConfigInterfaces;

--- a/WeddingWebsite/Models/ConfigInterfaces/ICredentials.cs
+++ b/WeddingWebsite/Models/ConfigInterfaces/ICredentials.cs
@@ -1,6 +1,9 @@
-﻿namespace WeddingWebsite.Models.ConfigInterfaces;
+﻿using WeddingWebsite.Core.Emails;
+
+namespace WeddingWebsite.Models.ConfigInterfaces;
 
 public interface ICredentials
 {
     public string GoogleMaps { get; }
+    public EmailConfiguration EmailConfiguration { get; }
 }

--- a/WeddingWebsite/Models/Emails/EmailFilters.cs
+++ b/WeddingWebsite/Models/Emails/EmailFilters.cs
@@ -1,0 +1,27 @@
+﻿using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails;
+
+public record EmailFilters(
+    NumGuestsFilter NumGuestsFilter = NumGuestsFilter.Any,
+    RsvpStatusFilter RsvpStatusFilter = RsvpStatusFilter.Any,
+    bool RsvpStatusMatchAll = false
+)
+{
+    public bool GuestMatchesRsvpStatus(Guest guest)
+    {
+        switch (RsvpStatusFilter)
+        {
+            case RsvpStatusFilter.NotNo:
+                return guest.Rsvp != RsvpStatus.No;
+            case RsvpStatusFilter.No:
+                return guest.Rsvp == RsvpStatus.No;
+            case RsvpStatusFilter.Waiting:
+                return guest.Rsvp == RsvpStatus.NotResponded;
+            case RsvpStatusFilter.Yes:
+                return guest.Rsvp == RsvpStatus.Yes;
+        }
+
+        return true;
+    }
+}

--- a/WeddingWebsite/Models/Emails/EmailStatus.cs
+++ b/WeddingWebsite/Models/Emails/EmailStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace WeddingWebsite.Models.Emails;
+
+public enum EmailStatus
+{
+    Sending,
+    Sent,
+    Failed,
+    NotStarted
+}

--- a/WeddingWebsite/Models/Emails/EmailStatus.cs
+++ b/WeddingWebsite/Models/Emails/EmailStatus.cs
@@ -5,5 +5,6 @@ public enum EmailStatus
     Sending,
     Sent,
     Failed,
-    NotStarted
+    NotStarted,
+    Waiting
 }

--- a/WeddingWebsite/Models/Emails/EmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/EmailVariable.cs
@@ -47,7 +47,7 @@ public abstract class EmailVariable
     /// </summary>
     public string Apply(string input, AccountWithGuests account, EmailFilters filters)
     {
-        var patternWithArgs = $@"%{Pattern}(?:\(([^%]+)\))?%";
+        var patternWithArgs = $@"%{Pattern}(?:\(([a-zA-Z_]+)\))?%";
         return System.Text.RegularExpressions.Regex.Replace(input, patternWithArgs, match =>
         {
             var args = match.Groups[1].Value; // This will be empty if there are no parentheses

--- a/WeddingWebsite/Models/Emails/EmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/EmailVariable.cs
@@ -1,0 +1,57 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Emails.Variables;
+
+namespace WeddingWebsite.Models.Emails;
+
+/// <summary>
+/// Email variable base class.
+/// </summary>
+public abstract class EmailVariable
+{
+    /// <summary>
+    /// Pattern without % or parameters, e.g. "FIRST_NAMES".
+    /// </summary>
+    public abstract string Pattern { get; }
+    
+    /// <summary>
+    /// Method to get the value given an account and filters.
+    /// </summary>
+    public abstract string GetValue(AccountWithGuests account, EmailFilters filters, string args);
+    
+    /// <summary>
+    /// Description for user info.
+    /// </summary>
+    public abstract string Description { get; }
+    
+    /// <summary>
+    /// Example for user info.
+    /// </summary>
+    public abstract string Example { get; }
+
+    /// <summary>
+    /// All available email variables.
+    /// </summary>
+    public static IEnumerable<EmailVariable> EmailVariables =>
+    [
+        new EmailEmailVariable(),
+        new UsernameEmailVariable(),
+        new FirstNamesEmailVariable(),
+        new FamilyNameEmailVariable(),
+        new FullNamesEmailVariable(),
+        new GroupedNamesEmailVariable(),
+        new NumGuestsEmailVariable()
+    ];
+
+    /// <summary>
+    /// Apply this filter to input text, returning the new text
+    /// </summary>
+    public string Apply(string input, AccountWithGuests account, EmailFilters filters)
+    {
+        var patternWithArgs = $@"%{Pattern}(?:\(([^%]+)\))?%";
+        return System.Text.RegularExpressions.Regex.Replace(input, patternWithArgs, match =>
+        {
+            var args = match.Groups[1].Value; // This will be empty if there are no parentheses
+            return GetValue(account, filters, args);
+        });
+    }
+}

--- a/WeddingWebsite/Models/Emails/EmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/EmailVariable.cs
@@ -31,7 +31,7 @@ public abstract class EmailVariable
     /// <summary>
     /// All available email variables.
     /// </summary>
-    public static IEnumerable<EmailVariable> EmailVariables =>
+    public static readonly IEnumerable<EmailVariable> EmailVariables =
     [
         new EmailEmailVariable(),
         new UsernameEmailVariable(),

--- a/WeddingWebsite/Models/Emails/EmailVariableWithGuestFilters.cs
+++ b/WeddingWebsite/Models/Emails/EmailVariableWithGuestFilters.cs
@@ -1,0 +1,36 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails;
+
+public abstract class EmailVariableWithGuestFilters : EmailVariable
+{
+    /// <summary>
+    /// Supplies the already filtered guests to your custom method.
+    /// </summary>
+    public abstract string GetValueGuests(IList<Guest> guests);
+    
+    /// <summary>
+    /// Filter the guests and then call base class method to get the value.
+    /// </summary>
+    public override string GetValue(AccountWithGuests account, EmailFilters filters, string args)
+    {
+        switch (args.ToUpper())
+        {
+            case "ALL":
+                return GetValueGuests(account.Guests.ToList());
+            case "RSVP_YES":
+                var rsvpYesGuests = account.Guests.Where(g => g.Rsvp == RsvpStatus.Yes);
+                return GetValueGuests(rsvpYesGuests.ToList());
+            case "RSVP_NO":
+                var rsvpNoGuests = account.Guests.Where(g => g.Rsvp == RsvpStatus.No);
+                return GetValueGuests(rsvpNoGuests.ToList());
+            case "RSVP_WAITING":
+                var rsvpWaitingGuests = account.Guests.Where(g => g.Rsvp == RsvpStatus.NotResponded);
+                return GetValueGuests(rsvpWaitingGuests.ToList());
+            default:
+                var matchingGuests = account.Guests.Where(filters.GuestMatchesRsvpStatus);
+                return GetValueGuests(matchingGuests.ToList());
+        }
+    }
+}

--- a/WeddingWebsite/Models/Emails/NumGuestsFilter.cs
+++ b/WeddingWebsite/Models/Emails/NumGuestsFilter.cs
@@ -1,0 +1,9 @@
+﻿namespace WeddingWebsite.Models.Emails;
+
+public enum NumGuestsFilter
+{
+    Any,
+    None,
+    One,
+    Multiple,
+}

--- a/WeddingWebsite/Models/Emails/RsvpStatusFilter.cs
+++ b/WeddingWebsite/Models/Emails/RsvpStatusFilter.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel;
-
-namespace WeddingWebsite.Models.Emails;
+﻿namespace WeddingWebsite.Models.Emails;
 
 public enum RsvpStatusFilter
 {

--- a/WeddingWebsite/Models/Emails/RsvpStatusFilter.cs
+++ b/WeddingWebsite/Models/Emails/RsvpStatusFilter.cs
@@ -1,0 +1,12 @@
+﻿using System.ComponentModel;
+
+namespace WeddingWebsite.Models.Emails;
+
+public enum RsvpStatusFilter
+{
+    Any,
+    NotNo,
+    Waiting,
+    Yes,
+    No
+}

--- a/WeddingWebsite/Models/Emails/Variables/EmailEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/EmailEmailVariable.cs
@@ -1,0 +1,15 @@
+﻿using WeddingWebsite.Data.Models;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class EmailEmailVariable : EmailVariable
+{
+    public override string Pattern => "EMAIL";
+    public override string Example => "bob@example.com";
+    public override string Description => "Recipient email address.";
+    
+    public override string GetValue(AccountWithGuests account, EmailFilters filters, string args)
+    {
+        return account.Email ?? "";
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/FamilyNameEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/FamilyNameEmailVariable.cs
@@ -15,6 +15,7 @@ public class FamilyNameEmailVariable : EmailVariableWithGuestFilters
         {
             return $"{guests.First().Name.Last} family";
         }
+        else
         {
             return new FirstNamesEmailVariable().GetValueGuests(guests);
         }

--- a/WeddingWebsite/Models/Emails/Variables/FamilyNameEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/FamilyNameEmailVariable.cs
@@ -1,0 +1,22 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class FamilyNameEmailVariable : EmailVariableWithGuestFilters
+{
+    public override string Pattern => "FAMILY_NAME";
+    public override string Example => "Smith family";
+    public override string Description => "If multiple surnames or one guest, fallback to %FIRST_NAMES%.";
+    
+    public override string GetValueGuests(IList<Guest> guests)
+    {
+        if (guests.GroupBy(g => g.Name.Last).Count() == 1 && guests.Count > 1)
+        {
+            return $"{guests.First().Name.Last} family";
+        }
+        {
+            return new FirstNamesEmailVariable().GetValueGuests(guests);
+        }
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/FirstNamesEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/FirstNamesEmailVariable.cs
@@ -1,0 +1,30 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class FirstNamesEmailVariable : EmailVariableWithGuestFilters
+{
+    public override string Pattern => "FIRST_NAMES";
+    public override string Example => "Bob and Alice";
+    public override string Description => "First names.";
+    
+    public override string GetValueGuests(IList<Guest> guests)
+    {
+        if (!guests.Any())
+        {
+            return "";
+        }
+        if (guests.Count == 1)
+        {
+            return guests.Single().Name.First;
+        }
+        if (guests.Count == 2)
+        {
+            return $"{guests.First().Name.First} and {guests.Last().Name.First}";
+        } 
+        var allButLast = guests.Take(guests.Count - 1).Select(g => g.Name.First);
+        var last = guests.Last().Name.First;
+        return $"{string.Join(", ", allButLast)}, and {last}";
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/FullNamesEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/FullNamesEmailVariable.cs
@@ -1,0 +1,30 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class FullNamesEmailVariable : EmailVariableWithGuestFilters
+{
+    public override string Pattern => "FULL_NAMES";
+    public override string Example => "Bob Smith and Alice Smith";
+    public override string Description => "Full names.";
+    
+    public override string GetValueGuests(IList<Guest> guests)
+    {
+        if (!guests.Any())
+        {
+            return "";
+        }
+        if (guests.Count == 1)
+        {
+            return guests.Single().Name.Full;
+        }
+        if (guests.Count == 2)
+        {
+            return $"{guests.First().Name.Full} and {guests.Last().Name.Full}";
+        } 
+        var allButLast = guests.Take(guests.Count - 1).Select(g => g.Name.Full);
+        var last = guests.Last().Name.Full;
+        return $"{string.Join(", ", allButLast)}, and {last}";
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/GroupedNamesEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/GroupedNamesEmailVariable.cs
@@ -21,6 +21,7 @@ public class GroupedNamesEmailVariable : EmailVariableWithGuestFilters
             var last = guests.Last().Name.First;
             return $"{string.Join(", ", allButLast)}, and {last} {guests.First().Name.Last}";
         }
+        else
         {
             return new FullNamesEmailVariable().GetValueGuests(guests);
         }

--- a/WeddingWebsite/Models/Emails/Variables/GroupedNamesEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/GroupedNamesEmailVariable.cs
@@ -1,0 +1,28 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class GroupedNamesEmailVariable : EmailVariableWithGuestFilters
+{
+    public override string Pattern => "GROUPED_NAMES";
+    public override string Example => "Bob and Alice Smith";
+    public override string Description => "If multiple surnames, fallback to %FULL_NAMES%.";
+    
+    public override string GetValueGuests(IList<Guest> guests)
+    {
+        if (guests.GroupBy(g => g.Name.Last).Count() == 1 && guests.Count > 1)
+        {
+            if (guests.Count == 2)
+            {
+                return $"{guests.First().Name.First} and {guests.Last().Name.First} {guests.First().Name.Last}";
+            }
+            var allButLast = guests.Take(guests.Count - 1).Select(g => g.Name.First);
+            var last = guests.Last().Name.First;
+            return $"{string.Join(", ", allButLast)}, and {last} {guests.First().Name.Last}";
+        }
+        {
+            return new FullNamesEmailVariable().GetValueGuests(guests);
+        }
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/NumGuestsEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/NumGuestsEmailVariable.cs
@@ -1,0 +1,16 @@
+﻿using WeddingWebsite.Data.Models;
+using WeddingWebsite.Models.Accounts;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class NumGuestsEmailVariable : EmailVariableWithGuestFilters
+{
+    public override string Pattern => "NUM_GUESTS";
+    public override string Example => "2";
+    public override string Description => "Number of guests on the account.";
+    
+    public override string GetValueGuests(IList<Guest> guests)
+    {
+        return guests.Count.ToString();
+    }
+}

--- a/WeddingWebsite/Models/Emails/Variables/UsernameEmailVariable.cs
+++ b/WeddingWebsite/Models/Emails/Variables/UsernameEmailVariable.cs
@@ -1,0 +1,15 @@
+﻿using WeddingWebsite.Data.Models;
+
+namespace WeddingWebsite.Models.Emails.Variables;
+
+public class UsernameEmailVariable : EmailVariable
+{
+    public override string Pattern => "USERNAME";
+    public override string Example => "bob123";
+    public override string Description => "Username of the account.";
+    
+    public override string GetValue(AccountWithGuests account, EmailFilters filters, string args)
+    {
+        return account.UserName ?? "";
+    }
+}

--- a/WeddingWebsite/Program.cs
+++ b/WeddingWebsite/Program.cs
@@ -10,6 +10,7 @@ using WeddingWebsite.Config.Strings;
 using WeddingWebsite.Config.ThemeAndLayout;
 using WeddingWebsite.Config.WeddingDetails;
 using WeddingWebsite.Core;
+using WeddingWebsite.Core.Emails;
 using WeddingWebsite.Data;
 using WeddingWebsite.Data.Stores;
 using WeddingWebsite.Models.ConfigInterfaces;
@@ -53,6 +54,7 @@ builder.Services.AddScoped<IStore, Store>();
 builder.Services.AddScoped<IRsvpStore, RsvpStore>();
 builder.Services.AddScoped<IRegistryStore, RegistryStore>();
 builder.Services.AddScoped<ITodoStore, TodoStore>();
+builder.Services.AddScoped<IEmailSender, MailKitEmailSender>();
 
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/WeddingWebsite/WeddingWebsite.csproj
+++ b/WeddingWebsite/WeddingWebsite.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="MailKit" Version="4.15.1" />
       <PackageReference Include="Microsoft.AspNetCore.ApiAuthorization.IdentityServer" Version="7.0.20" />
       <PackageReference Include="Microsoft.AspNetCore.Authorization.Policy" Version="2.3.0" />
       <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="9.0.8" />


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Introduces the new mass emailing system which allows admins to send an email to all guests matching certain criteria, such as guests that have not RSVP'd. This will also facilitate other email-related features in future.

This is accessed from a link on the admin page:
<img width="634" height="116" alt="image" src="https://github.com/user-attachments/assets/8e1dfce5-e928-44ba-b334-f2331e2970b1" />

The first page allows you to choose the recipients and write the message.
<img width="816" height="737" alt="image" src="https://github.com/user-attachments/assets/d9de3a45-6c37-49e5-ad19-144297599cdd" />

The variables available are clearly documented on this page:
<img width="803" height="676" alt="image" src="https://github.com/user-attachments/assets/8bba9453-c3cc-4f9f-a5e7-f56670b55c6c" />

The placeholder message with HTML enabled is as follows:
<img width="808" height="694" alt="image" src="https://github.com/user-attachments/assets/4fee64dd-4161-45c9-a058-e0cc28e80f65" />

This sends an immediate test email to the logged in user, and advances to the next screen:
<img width="812" height="708" alt="image" src="https://github.com/user-attachments/assets/566b7d6c-c082-4de9-a4a9-9a5c54913e6b" />

The recipients can then be checked and modified if needed before sending the emails. If there are more than 10 recipients, an additional confirmation appears that requires the user to type in "I want to send an email to X people" to make sure that they are sure. If there are less than 10 people, there is no additional confirmation and it goes straight into sending them.

<img width="477" height="144" alt="image" src="https://github.com/user-attachments/assets/af7d408e-c9ca-4980-9b6f-0497ecc8924e" />

If anything goes wrong, it will continue to attempt every email until reaching the end of the list. This data is not stored anywhere after the user has navigated off the page - if they want to view a history of messages, they need to check the "Sent" folder in the email client.

Avoiding ratelimits - Several features were added to help avoid hitting rate limits and making email clients grumpy. There is an optional delay per email which defaults to 0 but could be set to e.g. 5 seconds to make it seem more natural. It is also possible to pause and resume delivery of the emails manually to space things out or just generally cancel it. It is also automatically paused upon encountering an error.

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Applicable - new feature.

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
Nope - all admin-only stuff.

## Any interesting design decisions?
It is implemented in just one page as it makes data transfer easy and it is easy to "go back" while maintaining the current settings. It is not optional to send a test email - this is very important! However, the logged in user is automatically excluded from the next stage as they have already received one.

I also could've probably made a separate PR for the email system alone, but I kinda needed the user-facing stuff to test it properly.

## Does this close any issues?
Closes #103
Closes #105 