### PR TITLE
Fix page specific titles

### DIFF
--- a/WeddingWebsite/Components/App.razor
+++ b/WeddingWebsite/Components/App.razor
@@ -13,7 +13,14 @@
     <script src="@Assets["_content/MudBlazor/MudBlazor.min.js"]"></script>
     <ImportMap/>
     <link rel="icon" type="image/jpg" href="/img/favicon.jpg"/>
-    <HeadOutlet/>
+    @if (RenderModeForPage == InteractiveServer)
+    {
+        <HeadOutlet @rendermode="new InteractiveServerRenderMode(prerender: false)"/>
+    }
+    else
+    {
+        <HeadOutlet/>
+    }
 </head>
 
 <body>

--- a/WeddingWebsite/Components/App.razor
+++ b/WeddingWebsite/Components/App.razor
@@ -34,7 +34,7 @@
     [CascadingParameter]
     private HttpContext HttpContext { get; set; } = default!;
 
-    private IComponentRenderMode? RenderModeForPage => HttpContext.Request.Path.StartsWithSegments("/Account")
+    private IComponentRenderMode? RenderModeForPage => (HttpContext.Request.Path.StartsWithSegments("/Account") && !HttpContext.Request.Path.Equals("/Account"))
         ? null
         : InteractiveServer;
 }

--- a/WeddingWebsite/Components/Pages/Account.razor
+++ b/WeddingWebsite/Components/Pages/Account.razor
@@ -29,8 +29,6 @@
 @inject IStringProvider StringProvider
 @inject IRsvpForm RsvpForm
 
-@rendermode InteractiveServer
-
 <PageTitle>@StringProvider.MyAccount</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">

--- a/WeddingWebsite/Components/Pages/Account.razor
+++ b/WeddingWebsite/Components/Pages/Account.razor
@@ -29,7 +29,7 @@
 @inject IStringProvider StringProvider
 @inject IRsvpForm RsvpForm
 
-<PageTitle>@StringProvider.MyAccount</PageTitle>
+<PageTitle>@StringProvider.PageTitle("My Account")</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/Pages/Account.razor
+++ b/WeddingWebsite/Components/Pages/Account.razor
@@ -29,7 +29,7 @@
 @inject IStringProvider StringProvider
 @inject IRsvpForm RsvpForm
 
-<PageTitle>@StringProvider.PageTitle("My Account")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(@StringProvider.MyAccount)</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/Pages/Admin/Admin.razor
+++ b/WeddingWebsite/Components/Pages/Admin/Admin.razor
@@ -1,12 +1,15 @@
 ﻿@page "/Admin"
 @using WeddingWebsite.Components.Admin
 @using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Models.ConfigInterfaces
 
 @attribute [Authorize(Roles = "Admin")]
 
 @layout SimpleLayout
 
-<PageTitle>Admin Page</PageTitle>
+@inject IStringProvider StringProvider
+
+<PageTitle>@StringProvider.PageTitle("Admin Page")</PageTitle>
 
 <h1>Admin Page</h1>
 

--- a/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ComposeEmail.razor
@@ -10,16 +10,18 @@
 @using WeddingWebsite.Models.Emails
 @using WeddingWebsite.Services
 @using WeddingWebsite.Components.Elements
+@using WeddingWebsite.Models.ConfigInterfaces
 
 @inject IEmailSender EmailSender
 @inject IAdminService AdminService
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IStringProvider StringProvider
 
 @attribute [Authorize(Roles = "Admin")]
 
 @layout SimpleLayout
 
-<PageTitle>Compose Email</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Compose Email")</PageTitle>
 
 @if (!ReadyToSend)
 {

--- a/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ManageAccount.razor
@@ -9,6 +9,7 @@
 @using WeddingWebsite.Models
 @using WeddingWebsite.Models.Accounts
 @using WeddingWebsite.Services
+@using WeddingWebsite.Models.ConfigInterfaces
 
 @layout SimpleLayout
 
@@ -19,8 +20,9 @@
 @inject IAccountService AccountService
 @inject NavigationManager NavigationManager
 @inject AuthenticationStateProvider AuthenticationStateProvider
+@inject IStringProvider StringProvider
 
-<PageTitle>Manage Account</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Manage Account")</PageTitle>
 
 <h1 class="text-center">Manage Account</h1>
 

--- a/WeddingWebsite/Components/Pages/Admin/ManageGuest.razor
+++ b/WeddingWebsite/Components/Pages/Admin/ManageGuest.razor
@@ -22,8 +22,9 @@
 @inject AuthenticationStateProvider AuthenticationStateProvider
 @inject IRsvpService RsvpService
 @inject IRsvpForm RsvpForm
+@inject IStringProvider StringProvider
 
-<PageTitle>Manage Account</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Manage Account")</PageTitle>
 
 <div class="narrow-section">
     <h1 class="text-center">Manage Guest</h1>

--- a/WeddingWebsite/Components/Pages/Admin/TodoList.razor
+++ b/WeddingWebsite/Components/Pages/Admin/TodoList.razor
@@ -13,8 +13,9 @@
 
 @inject ITodoService TodoService
 @inject IWebsiteConfig Config
+@inject IStringProvider StringProvider
 
-<PageTitle>Todo List</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Todo List")</PageTitle>
 
 <Section Center="true">
     <h1>To-Do List</h1>

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -22,7 +22,7 @@
 
 @attribute [AllowAnonymous]
 
-<PageTitle>@StringProvider.PageTitle("Log in")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(StringProvider.Login)</PageTitle>
 
 <img class="background-image" src="@WeddingDetails.MainImage.Url" alt="@WeddingDetails.MainImage.AltText"/>
 

--- a/WeddingWebsite/Components/Pages/Auth/Login.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Login.razor
@@ -22,7 +22,7 @@
 
 @attribute [AllowAnonymous]
 
-<PageTitle>Log in</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Log in")</PageTitle>
 
 <img class="background-image" src="@WeddingDetails.MainImage.Url" alt="@WeddingDetails.MainImage.AltText"/>
 

--- a/WeddingWebsite/Components/Pages/Auth/Register.razor
+++ b/WeddingWebsite/Components/Pages/Auth/Register.razor
@@ -10,6 +10,7 @@
 @using WeddingWebsite.Components.Sections
 @using WeddingWebsite.Core
 @using WeddingWebsite.Data
+@using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Services
 
 @inject UserManager<Account> UserManager
@@ -18,12 +19,13 @@
 @inject ILogger<Register> Logger
 @inject NavigationManager NavigationManager
 @inject IAdminService AdminService
+@inject IStringProvider StringProvider
 
 @attribute [Authorize ( Roles = "Admin") ]
 
 @layout SimpleLayout
 
-<PageTitle>Register</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Register")</PageTitle>
 
 <Section>
     <div class="narrow-section">

--- a/WeddingWebsite/Components/Pages/Error.razor
+++ b/WeddingWebsite/Components/Pages/Error.razor
@@ -6,8 +6,9 @@
 @layout SimpleLayout
 
 @inject IWeddingDetails WeddingDetails
+@inject IStringProvider StringProvider
 
-<PageTitle>Error</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Error")</PageTitle>
 
 <h1 class="text-danger">Error</h1>
 

--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -6,7 +6,7 @@
 @inject IWeddingDetails WeddingDetails
 @inject IStringProvider StringProvider
 
-<PageTitle>@StringProvider.Gallery</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Gallery")</PageTitle>
 
 <div style="margin-top: 50px;"></div>
 

--- a/WeddingWebsite/Components/Pages/Gallery.razor
+++ b/WeddingWebsite/Components/Pages/Gallery.razor
@@ -6,7 +6,7 @@
 @inject IWeddingDetails WeddingDetails
 @inject IStringProvider StringProvider
 
-<PageTitle>@StringProvider.PageTitle("Gallery")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(@StringProvider.Gallery)</PageTitle>
 
 <div style="margin-top: 50px;"></div>
 

--- a/WeddingWebsite/Components/Pages/Home.razor
+++ b/WeddingWebsite/Components/Pages/Home.razor
@@ -15,7 +15,7 @@
 
 @layout NavbarScrollLayout
 
-<PageTitle>@StringProvider.Home</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Home")</PageTitle>
 
 @((MarkupString)@WeddingDetails.MainImage.GetHtml("main-image"))
 

--- a/WeddingWebsite/Components/Pages/Home.razor
+++ b/WeddingWebsite/Components/Pages/Home.razor
@@ -15,7 +15,7 @@
 
 @layout NavbarScrollLayout
 
-<PageTitle>@StringProvider.PageTitle("Home")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(StringProvider.Home)</PageTitle>
 
 @((MarkupString)@WeddingDetails.MainImage.GetHtml("main-image"))
 

--- a/WeddingWebsite/Components/Pages/Registry/EditRegistryClaim.razor
+++ b/WeddingWebsite/Components/Pages/Registry/EditRegistryClaim.razor
@@ -3,6 +3,7 @@
 @using System.ComponentModel.DataAnnotations
 @using WeddingWebsite.Components.Elements
 @using WeddingWebsite.Components.Layouts
+@using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Services
 
@@ -10,12 +11,13 @@
 @inject IAdminService AdminService
 @inject IAccountService AccountService
 @inject NavigationManager NavigationManager
+@inject IStringProvider StringProvider
 
 @layout SimpleLayout
 
 @attribute [Authorize(Roles = "Admin")]
 
-<PageTitle>Edit Registry Claim</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Edit Registry Claim")</PageTitle>
 
 <h1>Manage Claim</h1>
 <p>Modify as many or as few details as you want, then press save at the bottom. Please note that this will override any edits made while this tab is left open, including fields that you are not modifying.</p>

--- a/WeddingWebsite/Components/Pages/Registry/ManageRegistryItem.razor
+++ b/WeddingWebsite/Components/Pages/Registry/ManageRegistryItem.razor
@@ -3,15 +3,17 @@
 @using System.ComponentModel.DataAnnotations
 @using WeddingWebsite.Components.Layouts
 @using WeddingWebsite.Components.Containers
+@using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Services
 
 @inject IRegistryService RegistryService
 @inject NavigationManager NavigationManager
+@inject IStringProvider StringProvider
 
 @layout SimpleLayout
 
-<PageTitle>Edit Registry Item</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Edit Registry Item")</PageTitle>
 
 <h1>Manage Item</h1>
 <p>Modify as many or as few details as you want, then press save at the bottom. Please note that this will override any edits made while this tab is left open, including to fields that you are not modifying.</p>

--- a/WeddingWebsite/Components/Pages/Registry/NewRegistryItem.razor
+++ b/WeddingWebsite/Components/Pages/Registry/NewRegistryItem.razor
@@ -11,10 +11,11 @@
 @inject IRegistryService RegistryService
 @inject NavigationManager NavigationManager
 @inject IWebsiteConfig Config
+@inject IStringProvider StringProvider
 
 @attribute [Authorize(Roles = "Admin")]
 
-<PageTitle>New Registry Item</PageTitle>
+<PageTitle>@StringProvider.PageTitle("New Registry Item")</PageTitle>
 
 <h1>New Registry Item</h1>
 <p class="mb">Add a new item to the registry. Please note that there will be more options available after creating in the edit page - this page is designed to provide the most frequently used options to create items quickly.</p>

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -20,7 +20,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IStringProvider StringProvider
 
-<PageTitle>@StringProvider.PageTitle($"Registry - {Item?.GenericName}")</PageTitle>
+<PageTitle>@StringProvider.PageTitle($"{StringProvider.Registry} - {Item?.GenericName}")</PageTitle>
 
 @if (Item == null)
 {

--- a/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryItemPage.razor
@@ -20,7 +20,7 @@
 @inject AuthenticationStateProvider AuthStateProvider
 @inject IStringProvider StringProvider
 
-<PageTitle>Registry - @Item?.GenericName</PageTitle>
+<PageTitle>@StringProvider.PageTitle($"Registry - {Item?.GenericName}")</PageTitle>
 
 @if (Item == null)
 {

--- a/WeddingWebsite/Components/Pages/Registry/RegistryPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryPage.razor
@@ -7,7 +7,7 @@
 @inject IWebsiteConfig Config
 @inject IStringProvider StringProvider
 
-<PageTitle>@StringProvider.Registry</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Registry")</PageTitle>
 
 @if (Config.OptionalFeatures.Registry.IsActive())
 {

--- a/WeddingWebsite/Components/Pages/Registry/RegistryPage.razor
+++ b/WeddingWebsite/Components/Pages/Registry/RegistryPage.razor
@@ -7,7 +7,7 @@
 @inject IWebsiteConfig Config
 @inject IStringProvider StringProvider
 
-<PageTitle>@StringProvider.PageTitle("Registry")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(@StringProvider.Registry)</PageTitle>
 
 @if (Config.OptionalFeatures.Registry.IsActive())
 {

--- a/WeddingWebsite/Components/Pages/Rsvp/RsvpChooseGuest.razor
+++ b/WeddingWebsite/Components/Pages/Rsvp/RsvpChooseGuest.razor
@@ -18,7 +18,7 @@
 
 @rendermode InteractiveServer
 
-<PageTitle>@StringProvider.Rsvp</PageTitle>
+<PageTitle>@StringProvider.PageTitle("RSVP")</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/Pages/Rsvp/RsvpChooseGuest.razor
+++ b/WeddingWebsite/Components/Pages/Rsvp/RsvpChooseGuest.razor
@@ -18,7 +18,7 @@
 
 @rendermode InteractiveServer
 
-<PageTitle>@StringProvider.PageTitle("RSVP")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(StringProvider.Rsvp)</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/Pages/Rsvp/RsvpSubmitted.razor
+++ b/WeddingWebsite/Components/Pages/Rsvp/RsvpSubmitted.razor
@@ -18,7 +18,7 @@
 
 @rendermode InteractiveServer
 
-<PageTitle>@StringProvider.Rsvp</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Rsvp")</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/Pages/Rsvp/RsvpSubmitted.razor
+++ b/WeddingWebsite/Components/Pages/Rsvp/RsvpSubmitted.razor
@@ -18,7 +18,7 @@
 
 @rendermode InteractiveServer
 
-<PageTitle>@StringProvider.PageTitle("Rsvp")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(StringProvider.Rsvp)</PageTitle>
 
 <CascadingValue TValue="SectionTheme" Value="ThemeNoBackground">
     <Section Center="true">

--- a/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
+++ b/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
@@ -20,7 +20,7 @@
 @inject IAdminService AdminService
 @inject IDialogService DialogService
 
-<PageTitle>@StringProvider.PageTitle("Rsvp")</PageTitle>
+<PageTitle>@StringProvider.PageTitle(@StringProvider.Rsvp)</PageTitle>
 
 @if (Guest == null)
 {

--- a/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
+++ b/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
@@ -20,7 +20,7 @@
 @inject IAdminService AdminService
 @inject IDialogService DialogService
 
-<PageTitle>@StringProvider.Rsvp</PageTitle>
+<PageTitle>@StringProvider.PageTitle("Rsvp")</PageTitle>
 
 @if (Guest == null)
 {

--- a/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
+++ b/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
@@ -10,7 +10,8 @@ namespace WeddingWebsite.Config.Strings;
 /// </summary>
 public class StandardBritishEnglish : IStringProvider
 {
-    public string PageTitle(string specificTitle) => $"{specificTitle} - Wedding Website";
+    public string WebsiteTitle => "Wedding Website";
+    public string PageTitle(string specificTitle) => specificTitle == "" ? WebsiteTitle : $"{specificTitle} - {WebsiteTitle}";
     
     public string Month => "Month";
     public string Week => "Week";
@@ -27,7 +28,6 @@ public class StandardBritishEnglish : IStringProvider
     public string Submit => "Submit";
     public string Cancel => "Cancel";
     
-    public string WebsiteTitle => "Wedding Website";
     public string MyAccount => "My Account";
     public string Logout => "Logout";
     public string Login => "Log in";

--- a/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
+++ b/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
@@ -10,6 +10,8 @@ namespace WeddingWebsite.Config.Strings;
 /// </summary>
 public class StandardBritishEnglish : IStringProvider
 {
+    public string PageTitle(string specificTitle) => $"{specificTitle} - Wedding Website";
+    
     public string Month => "Month";
     public string Week => "Week";
     public string Day => "Day";

--- a/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
+++ b/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
@@ -11,6 +11,7 @@ namespace WeddingWebsite.Models.ConfigInterfaces;
 /// </summary>
 public interface IStringProvider
 {
+    string WebsiteTitle { get; }
     string PageTitle(string specificTitle);
     
     string Month { get; }
@@ -28,7 +29,6 @@ public interface IStringProvider
     string Submit { get; }
     string Cancel { get; }
     
-    string WebsiteTitle { get; }
     string MyAccount { get; }
     string Logout { get; }
     string Login { get; }

--- a/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
+++ b/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
@@ -5,12 +5,14 @@ namespace WeddingWebsite.Models.ConfigInterfaces;
 
 /// <summary>
 /// Customise all user-facing strings, either into a different language or just different wording.
-/// This only applies to stuff that your guests will see, so admin pages and error messages are excluded.
-/// This may be added in future, but isn't a priority.
-/// Occasionally, something is missed. If so, feel free to make a PR or an issue!
+/// This only applies to stuff that your guests will see, so admin-only pages are excluded from the string provider.
+/// Occasionally, something is missed. If you discover a guest-facing string that is not configurable in here, please
+/// create an issue and I will fix it!
 /// </summary>
 public interface IStringProvider
 {
+    string PageTitle(string specificTitle);
+    
     string Month { get; }
     string Week { get; }
     string Day { get; }

--- a/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
+++ b/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
@@ -4,8 +4,8 @@ using WeddingWebsite.Models.Registry;
 namespace WeddingWebsite.Models.ConfigInterfaces;
 
 /// <summary>
-/// Customise all user-facing strings, either into a different language or just different wording.
-/// This only applies to stuff that your guests will see, so admin-only pages are excluded from the string provider.
+/// Customise all user-facing strings, either into a different language or just different wording. This generally only
+/// applies to stuff that your guests will see, so admin-only pages are usually excluded from the string provider.
 /// Occasionally, something is missed. If you discover a guest-facing string that is not configurable in here, please
 /// create an issue and I will fix it!
 /// </summary>


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Previously, there was a bug in which page titles would not update as you navigate around the website, only when you refresh. This has been fixed. In addition, the titles are lengthened, adding " - Wedding Website" at the end (this is configurable). This is more descriptive than "Home" which doesn't say which website it's on.

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Configurable - go into StringProvider and set PageTitle to be equal to the specific title to restore old functionality.

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
Yes

## Any interesting design decisions?
Prerendering is disabled as it caused problems with the favicon.

## Does this close any issues?
Closes https://github.com/smileyface12349/wedding-website/issues/125 - not exactly what was described, but fixes the root cause.