### PR TITLE
Fix horizontal display of long attendance question

### DIFF
--- a/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
+++ b/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
@@ -48,6 +48,7 @@
                     <p><i>@StringProvider.RsvpFormDescriptionContact(WeddingDetails.GetContactMethod(ContactReason.Attendance)?.Text)</i></p>
                 }
             }
+            <button @onclick="StateHasChanged">hello</button>
             
             <h2>@StringProvider.RsvpAttendanceQuestion<span class="required-asterisk">*</span></h2>
             @if (RsvpConfig.LongAttendanceResponses)
@@ -80,6 +81,15 @@
 <style>
     body {
         @(Theme?.Background.GetBackgroundCss() ?? Config.Colours.Surface.GetBackgroundCss()) !important;
+    }
+    
+    @* Force vertical layout - otherwise it does row layout sometimes *@
+    .mud-radio-group {
+        flex-direction: column !important;
+        align-items: start !important;
+    }
+    .mud-ripple-radio {
+        margin-right: 5px;
     }
 </style>
 

--- a/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
+++ b/WeddingWebsite/Components/WeddingComponents/Rsvp/RsvpForm.razor
@@ -48,7 +48,6 @@
                     <p><i>@StringProvider.RsvpFormDescriptionContact(WeddingDetails.GetContactMethod(ContactReason.Attendance)?.Text)</i></p>
                 }
             }
-            <button @onclick="StateHasChanged">hello</button>
             
             <h2>@StringProvider.RsvpAttendanceQuestion<span class="required-asterisk">*</span></h2>
             @if (RsvpConfig.LongAttendanceResponses)


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Fixes a bug with the radio group in the long attendance question where it would show the options side-by-side before selecting an option (incorrect), and then vertically after selecting an option (correct).

Before:
<img width="528" height="89" alt="Image" src="https://github.com/user-attachments/assets/4c7d3202-6aea-448a-bbe7-b589290e6d4a" />

After:
<img width="467" height="117" alt="image" src="https://github.com/user-attachments/assets/5aa1e847-eb64-48d9-b360-8cc3573a9e6a" />

Note: Images differ slightly as they were taken on different wedding websites, but the idea is clear.

*Behaviour after selecting an option is unchanged.*

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable - old behaviour is considered a bug.

## Does any validation logic need adding/updating?
No.

## Are the strings configurable?
N/A

## Any interesting design decisions?
Just used manual CSS to force mudblazor to do it's stuff as I couldn't find any proper options.

## Does this close any issues?
Closes #127
