### PR TITLE
Improve registry filters

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -1,6 +1,7 @@
 ﻿@using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using WeddingWebsite.Components.Sections
+@using WeddingWebsite.Components.WeddingComponents
 @using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Models.WebsiteConfig

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -39,7 +39,7 @@
                         <Authorized>
                             @foreach (var filter in AdminExclusiveFilters)
                             {
-                                <MudSelectItem T="string" Value="@filter">@filter</MudSelectItem>
+                                <MudSelectItem T="string" Value="@filter">@filter<span title="Admin-only"> 🔒</span></MudSelectItem>
                             }
                         </Authorized>
                     </AuthorizeView>

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -120,11 +120,13 @@
     ];
     private readonly string[] AdminExclusiveFilters =
     [
-        "Claimed: Bring on day",
-        "Claimed: Deliver to us",
-        "Claimed: Money transfer",
-        "Claimed: Pending",
-        "Claimed: Completed",
+        "Claimed",
+        "Pending",
+        "Not yet received",
+        "Received",
+        "Bring on day",
+        "Deliver to us",
+        "Transfer money",
         "Hidden"
     ];
 
@@ -191,23 +193,31 @@
             return false;
         }
         // Admin exclusive filters
-        if (EnabledFilters.Contains("Claimed: Bring on day") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.BringOnDay))
+        if (EnabledFilters.Contains("Bring on day") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.BringOnDay))
         {
             return false;
         }
-        if (EnabledFilters.Contains("Claimed: Deliver to us") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.DeliverToUs))
+        if (EnabledFilters.Contains("Deliver to us") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.DeliverToUs))
         {
             return false;
         }
-        if (EnabledFilters.Contains("Claimed: Money transfer") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.TransferMoney))
+        if (EnabledFilters.Contains("Transfer money") && item.Claims.All(claim => claim.FulfillmentMethod != FulfillmentMethod.TransferMoney))
         {
             return false;
         }
-        if (EnabledFilters.Contains("Claimed: Pending") && item.Claims.All(c => c.IsCompleted))
+        if (EnabledFilters.Contains("Claimed") && !item.Claims.Any())
         {
             return false;
         }
-        if (EnabledFilters.Contains("Claimed: Completed") && item.Claims.All(c => !c.IsCompleted))
+        if (EnabledFilters.Contains("Received") && item.Claims.All(c => !c.IsReceived))
+        {
+            return false;
+        }
+        if (EnabledFilters.Contains("Pending") && item.Claims.All(c => c.IsCompleted))
+        {
+            return false;
+        }
+        if (EnabledFilters.Contains("Not yet received") && item.Claims.All(c => c.IsReceived))
         {
             return false;
         }

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -1,7 +1,6 @@
 ﻿@using System.Security.Claims
 @using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
 @using WeddingWebsite.Components.Sections
-@using WeddingWebsite.Components.WeddingComponents
 @using WeddingWebsite.Models.ConfigInterfaces
 @using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Models.WebsiteConfig
@@ -29,6 +28,11 @@
                     <MudSelectItem T="SortOrder" Value="SortOrder.Default">@StringProvider.Default</MudSelectItem>
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceLowToHigh">@StringProvider.PriceLowToHigh</MudSelectItem>
                     <MudSelectItem T="SortOrder" Value="SortOrder.PriceHighToLow">@StringProvider.PriceHighToLow</MudSelectItem>
+                    <AuthorizeView Roles="Admin">
+                        <Authorized>
+                            <MudSelectItem T="SortOrder" Value="SortOrder.RecentActivity">Recent Activity<span title="Admin-only"> 🔒</span></MudSelectItem>
+                        </Authorized>
+                    </AuthorizeView>
                 </MudSelect>
                 <MudSelect T="string" MultiSelection="true" @bind-Value="EnabledFiltersString" @bind-SelectedValues="EnabledFilters" Label="@StringProvider.Filters" OnClose="_ => SaveFilters()">
                     @foreach (var filter in AllFilters)
@@ -102,6 +106,17 @@
                     return item.Cost;
                 case SortOrder.PriceHighToLow:
                     return -item.Cost;
+                case SortOrder.RecentActivity:
+                    if (item.Claims.Any())
+                    {
+                        return -item.Claims.Max(c => c.ReceivedAt ?? c.CompletedAt ?? c.ClaimedAt).Ticks;
+                    }
+                    else
+                    {
+                        // Fallback ordering for items with no claims is default sort - nobody should be setting
+                        // priorities bigger than the number of ticks so these should appear after claimed items.
+                        return -item.Priority;
+                    }
                 default:
                     return 0;
             }
@@ -134,7 +149,8 @@
     {
         Default,
         PriceLowToHigh,
-        PriceHighToLow
+        PriceHighToLow,
+        RecentActivity
     }
     
     private SortOrder CurrentSortOrder { get; set; } = SortOrder.Default;


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Updates the admin-only filters. Previously we had:
- Claimed: Pending
- Claimed: Completed
This is bad as it doesn't have anything to do with received (often more interesting than completed), and it doesn't provide any way to show all claimed items at once. The new filters are:
- Claimed
- Pending (renamed from Claimed: Pending)
- Not yet received
- Received
This does remove the Claimed: Completed filter, but I wanted to keep the list short and focus on the most useful filters. There's also quite a strict character limit to avoid things wrapping onto several lines, so the wording might not be entirely clear but I hope it's as clear as possible with the space available.

This also adds a new sort order "Recent Activity". This will sort items that are claimed, completed or marked as received most recently. This, by definition, puts the claimed items above the unclaimed ones. It's also useful to have items bump to the top when marked as completed etc. so admins can review if they need to take action. You can also filter by not yet received, and spot items that have been stale for a while etc.

Finally, this update adds a padlock icon to filters and sort orders that are admin only, so that admins aren't worried that normal users are able to see this information.

<img width="308" height="454" alt="image" src="https://github.com/user-attachments/assets/fc98be09-a60f-4206-9299-1df6504f5159" />

<img width="300" height="274" alt="image" src="https://github.com/user-attachments/assets/24116b63-2517-40dd-a452-360f44c4ac5d" />

## What will existing users have to change when pulling these changes?
Nothing.

## If you're changing existing functionality, is this change configurable?
Not Configurable

Overall, these new options give much more flexibility. The only loss is the Claimed: Completed filter, and I don't think this is super helpful. It's also an admin-only change.

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
Nope - admin-only.

## Any interesting design decisions?
I tried several approaches for representing admin-only but an icon was the clear winner. The text (Admin) looked ugly and still took up a decent amount of space when small, and a different colour was a bit ugly and also unclear.

## Does this close any issues?
Closes #122