### PR TITLE
Add simple contact section

### DIFF
--- a/WeddingWebsite/Components/Pages/Home.razor
+++ b/WeddingWebsite/Components/Pages/Home.razor
@@ -61,6 +61,7 @@
         @if (sect is Section.SimpleTimeline) { <SimpleTimelineSection/> }
         @if (sect is Section.MeetWeddingParty party) { <MeetWeddingPartySection DisplayMode="party.DisplayMode" RolesLeft="party.RolesLeft" RolesRight="party.RolesRight"/> }
         @if (sect is Section.Contact contact) { <ContactSection ReasonsToShow="contact.ReasonsToShow" ShowUrgencyOption="contact.ShowUrgencyOption"/> }
+        @if (sect is Section.SimpleContact) { <SimpleContactSection/> }
         @if (sect is Section.DressCode dress) { <DressCodeSection WrapInBox="dress.WrapInBox" ShowContact="dress.ShowContact"/> }
         @if (sect is Section.VenueShowcase) { <VenueShowcaseSection/> }
         @if (sect is Section.Accommodation) { <AccommodationSection/> }

--- a/WeddingWebsite/Components/WeddingComponents/ContactInList.razor
+++ b/WeddingWebsite/Components/WeddingComponents/ContactInList.razor
@@ -1,0 +1,23 @@
+﻿@using WeddingWebsite.Models.People
+@using WeddingWebsite.Components.Containers
+
+<Box>
+    <h3>@Contact.NameAndRole</h3>
+    @foreach (var method in Contact.ContactDetails.GetOptions(Urgency).Methods) {
+        @if (method.Link != null) {
+            <p>@method.Type: <a href="@method.Link" target="_blank" rel="noopener noreferrer">@method.Text</a></p>
+        }
+        else {
+            <p>@method.Type: @method.Text</p>
+        }
+    }
+</Box>
+<div style="height: 10px;"></div>
+
+@code {
+    [Parameter]
+    public required IContact Contact { get; set; }
+    
+    [Parameter]
+    public required ContactUrgency Urgency { get; set; }
+}

--- a/WeddingWebsite/Components/WeddingComponents/ContactList.razor
+++ b/WeddingWebsite/Components/WeddingComponents/ContactList.razor
@@ -32,18 +32,7 @@
         }
     }
     @foreach (var contact in MatchingContacts) {
-        <Box>
-            <h3>@contact.NameAndRole</h3>
-            @foreach (var method in contact.ContactDetails.GetOptions(Urgency).Methods) {
-                @if (method.Link != null) {
-                    <p>@method.Type: <a href="@method.Link" target="_blank" rel="noopener noreferrer">@method.Text</a></p>
-                }
-                else {
-                    <p>@method.Type: @method.Text</p>
-                }
-            }
-        </Box>
-        <div style="height: 10px;"></div>
+        <ContactInList Contact="contact" Urgency="Urgency"/>
     }
 </div>
 

--- a/WeddingWebsite/Components/WeddingSections/SimpleContactSection.razor
+++ b/WeddingWebsite/Components/WeddingSections/SimpleContactSection.razor
@@ -1,0 +1,32 @@
+﻿@using WeddingWebsite.Components.Sections
+@using WeddingWebsite.Components.WeddingComponents
+@using WeddingWebsite.Models.ConfigInterfaces
+@using WeddingWebsite.Models.People
+
+@inject IWeddingDetails WeddingDetails
+@inject IStringProvider StringProvider
+
+<Section Id="contact">
+    <SectionHeading>@StringProvider.ContactUs</SectionHeading>
+    <div class="container">
+        @if (NotUrgentContacts.Any())
+        {
+            <p>@StringProvider.SimpleContactDescription</p>
+            @foreach (var contact in NotUrgentContacts) {
+                <ContactInList Contact="contact" Urgency="ContactUrgency.NotUrgent"/>
+            }
+        }
+        @if (UrgentContacts.Any())
+        {
+            <p>@StringProvider.SimpleContactDescriptionUrgent</p>
+            @foreach (var contact in UrgentContacts) {
+                <ContactInList Contact="contact" Urgency="ContactUrgency.Urgent"/>
+            }
+        }
+    </div>
+</Section>
+
+@code {
+    private IEnumerable<IContact> UrgentContacts => WeddingDetails.Contacts.Where(c => c.ContactDetails.GetOptions(ContactUrgency.Urgent).MatchesReason(ContactReason.Other));
+    private IEnumerable<IContact> NotUrgentContacts => WeddingDetails.Contacts.Where(c => c.ContactDetails.GetOptions(ContactUrgency.NotUrgent).MatchesReason(ContactReason.Other));
+}

--- a/WeddingWebsite/Components/WeddingSections/SimpleContactSection.razor.css
+++ b/WeddingWebsite/Components/WeddingSections/SimpleContactSection.razor.css
@@ -1,0 +1,10 @@
+﻿.container {
+    max-width: 400px;
+    margin: auto;
+}
+
+p {
+    margin-top: 10px;
+    margin-bottom: 10px;
+    text-align: center;
+}

--- a/WeddingWebsite/Components/WeddingSections/SimpleTimelineSection.razor
+++ b/WeddingWebsite/Components/WeddingSections/SimpleTimelineSection.razor
@@ -5,7 +5,7 @@
 @inject IWeddingDetails WeddingDetails
 @inject IStringProvider StringProvider
 
-<Section>
+<Section Id="timeline">
     <SectionHeading>@StringProvider.OrderOfTheDay</SectionHeading>
     <SimpleTimeline Events="WeddingDetails.Events"/>
 </Section>

--- a/WeddingWebsite/Config/Strings/FriendlyBritishEnglish.cs
+++ b/WeddingWebsite/Config/Strings/FriendlyBritishEnglish.cs
@@ -8,6 +8,9 @@ namespace WeddingWebsite.Config.Strings;
 /// </summary>
 public class FriendlyBritishEnglish : StandardBritishEnglish, IStringProvider
 {
+    public new string SimpleContactDescription => "If you have any questions or just want to get in touch, please don't hesitate to contact us using at:";
+    public new string SimpleContactDescriptionUrgent => "However, if it's urgent, please use one of these instead so that we can respond as soon as possible:";
+
     public new string AccountSharedWithGuests(int guestCount) =>  $"This account is shared between {guestCount} guest{(guestCount != 1 ? "s" : "")}. Feel free to share your login details amongst all the guests tied to this account (they won't be able to access the website otherwise).";
     
     public new string RegistryDescription1 => "Please do not feel under any pressure to give a gift - there is no obligation at all to do so! However, if you would like to give a gift, this page contains some suggestions of things we'd like. If you'd prefer to give something else, that's fine too!";

--- a/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
+++ b/WeddingWebsite/Config/Strings/StandardBritishEnglish.cs
@@ -75,6 +75,8 @@ public class StandardBritishEnglish : IStringProvider
     public string SuggestedContacts => "Suggested contacts";
     public string NoContactsBecauseNoCategory => "Choose a category of enquiry to see contacts.";
     public string NoContactsMatched => "No contacts found. Try a different search.";
+    public string SimpleContactDescription => "If you need to get in touch, please contact us at:";
+    public string SimpleContactDescriptionUrgent => "If it's urgent, try one of these instead:";
 
     public string Directions => "Directions";
 

--- a/WeddingWebsite/Config/ThemeAndLayout/DefaultConfig.cs
+++ b/WeddingWebsite/Config/ThemeAndLayout/DefaultConfig.cs
@@ -44,7 +44,7 @@ public class DefaultConfig : IWebsiteConfig
             new Section.HowWeMet(),
             new Section.Timeline(),
             new Section.DressCode(),
-            new Section.Contact()
+            new Section.SimpleContact()
         ];
         
         TopButtons = new TopButtonsConfig(

--- a/WeddingWebsite/Config/ThemeAndLayout/DemoConfig.cs
+++ b/WeddingWebsite/Config/ThemeAndLayout/DemoConfig.cs
@@ -61,6 +61,7 @@ public class DemoConfig : DefaultConfig, IWebsiteConfig
             new Section.VenueShowcase(new SectionTheme(orange, Colours.Primary, new BoxStyle(BoxType.FilledRounded, new SectionTheme(purple, darkDarkGreen, null)))),
             new Section.MeetWeddingParty(new SectionTheme(flowers, Colours.Primary, outlinedBox)),
             new Section.Accommodation(new SectionTheme(pink, Colours.Primary, filledBox)),
+            new Section.SimpleContact(new SectionTheme(blueGreen, Colours.Secondary, whiteFilledBox)),
             new Section.TravelDirections(new SectionTheme(Colours.Surface, Colours.Primary, outlinedBox)),
             new Section.SimpleTimeline(new SectionTheme(flowers2, Colours.Primary, filledBox)),
             new Section.Gallery(),

--- a/WeddingWebsite/Config/ThemeAndLayout/DemoConfig.cs
+++ b/WeddingWebsite/Config/ThemeAndLayout/DemoConfig.cs
@@ -15,7 +15,8 @@ public class DemoConfig : DefaultConfig, IWebsiteConfig
     );
     public new DemoMode DemoMode => new DemoMode.Enabled([]);
     public new IEnumerable<string> IgnoredValidationIssues => [
-        "You have both a Timeline and SimpleTimeline section. Since both sections display the same information, choose the level of detail you want and remove the other section."
+        "You have both a Timeline and SimpleTimeline section. Since both sections display the same information, choose the level of detail you want and remove the other section.",
+        "You have both a Contact and SimpleContact section. Since both sections display the same information, choose the level of detail you want and remove the other section."
     ];
 
     public DemoConfig() {

--- a/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
+++ b/WeddingWebsite/Models/ConfigInterfaces/IStringProvider.cs
@@ -76,6 +76,8 @@ public interface IStringProvider
     string SuggestedContacts { get; }
     string NoContactsBecauseNoCategory { get; }
     string NoContactsMatched { get; }
+    string SimpleContactDescription { get; }
+    string SimpleContactDescriptionUrgent { get; }
     
     string Directions { get; }
     

--- a/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
+++ b/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
@@ -22,6 +22,7 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
         Sections_ShouldNotHaveDuplicates(config);
         Sections_ShouldNotHaveTwoFractionalParallaxBackgrounds(config);
         Sections_ShouldNotHaveTimelineAndSimpleTimeline(config);
+        Sections_ShouldNotHaveContactsAndSimpleContacts(config);
         
         People_ThereIsABrideAndGroom(details);
         
@@ -339,11 +340,25 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
         }
     }
 
+    /// <summary>
+    /// Both of these sections do roughly the same thing, so it doesn't make sense to have both.
+    /// </summary>
     private void Sections_ShouldNotHaveTimelineAndSimpleTimeline(IWebsiteConfig config)
     {
         if (GetSection<Section.Timeline>(config) != null && GetSection<Section.SimpleTimeline>(config) != null)
         {
             Warning("You have both a Timeline and SimpleTimeline section. Since both sections display the same information, choose the level of detail you want and remove the other section.");
+        }
+    }
+    
+    /// <summary>
+    /// Both of these sections do roughly the same thing, so it doesn't make sense to have both.
+    /// </summary>
+    private void Sections_ShouldNotHaveContactsAndSimpleContacts(IWebsiteConfig config)
+    {
+        if (GetSection<Section.Contact>(config) != null && GetSection<Section.SimpleContact>(config) != null)
+        {
+            Warning("You have both a Contact and SimpleContact section. Since both sections display the same information, choose the level of detail you want and remove the other section.");
         }
     }
 

--- a/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
+++ b/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
@@ -41,6 +41,7 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
         Contacts_InformAboutLoginContact(details);
         Contacts_ShouldNotHaveDuplicates(details);
         Contacts_ShouldNotHaveEmptyMethods_IfReasonsIsNonEmpty(details);
+        Contacts_Simple_ShouldHaveAtLeastOneContact(details, config);
         
         VenueShowcase_ShouldNotHaveMoreThanTwoVenues(details, config);
         
@@ -294,6 +295,20 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
                     Warning($"The contact '{contact.NameAndRole}' has urgent options, but you have disabled the urgency toggle in settings. Either re-enable this toggle, or remove all urgent contact options, as the urgent contact options will be ignored.");
                 }
             }
+        }
+    }
+
+    /// <summary>
+    /// Doesn't make sense to have a section that isn't displaying anything.
+    /// </summary>
+    private void Contacts_Simple_ShouldHaveAtLeastOneContact(IWeddingDetails details, IWebsiteConfig config)
+    {
+        var section = GetSection<Section.SimpleContact>(config);
+        if (section == null) return;
+        var aContactMethod = details.GetContactMethod(ContactReason.Other);
+        if (aContactMethod == null)
+        {
+            Warning($"There are no contacts with reason 'Other', so no contacts will be visible in the simple contact section. Consider adding a contact method with this reason, or removing this section.");
         }
     }
     

--- a/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
+++ b/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
@@ -518,7 +518,8 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
     /// </summary>
     private void Navbar_ShouldNotHaveTimeline_IfThereIsNoTimelineSection(IWebsiteConfig config) {
         var timelineSection = GetSection<Section.Timeline>(config);
-        if (timelineSection == null) {
+        var simpleTimelineSection = GetSection<Section.SimpleTimeline>(config);
+        if (timelineSection == null && simpleTimelineSection == null) {
             foreach (var item in config.Navbar.Items) {
                 if (item.Link.Contains("#timeline", StringComparison.OrdinalIgnoreCase)) {
                     Error($"The navbar contains an item '{item.Text}' that links to the timeline, but there is no timeline section. Either add the timeline section, or remove this navbar item.");

--- a/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
+++ b/WeddingWebsite/Models/Validation/DetailsAndConfigValidator.cs
@@ -532,7 +532,8 @@ public class DetailsAndConfigValidator: IDetailsAndConfigValidator
     /// </summary>
     private void Navbar_ShouldNotHaveContact_IfThereIsNoContactSection(IWebsiteConfig config) {
         var contactSection = GetSection<Section.Contact>(config);
-        if (contactSection == null) {
+        var simpleContactSection = GetSection<Section.SimpleContact>(config);
+        if (contactSection == null && simpleContactSection == null) {
             foreach (var item in config.Navbar.Items) {
                 if (item.Link.Contains("#contact", StringComparison.OrdinalIgnoreCase)) {
                     Error($"The navbar contains an item '{item.Text}' that links to contact, but there is no contact section. Either add the contact section, or remove this navbar item.");

--- a/WeddingWebsite/Models/WebsiteConfig/Section.cs
+++ b/WeddingWebsite/Models/WebsiteConfig/Section.cs
@@ -63,6 +63,11 @@ public abstract record Section
     }
 
     /// <summary>
+    /// Shows the "Other" contact method only - useful if you want all enquiries to go to the same place.
+    /// </summary>
+    public sealed record SimpleContact(SectionTheme? Theme = null) : Section(Theme);
+
+    /// <summary>
     /// Shows the dress code. By default, it is shown inside a box.
     /// </summary>
     public sealed record DressCode(


### PR DESCRIPTION
## What does this PR do, and why do we need it?
The existing contact section is built around a dropdown for selecting a contact reason, however you might want to just send all enquiries to the same place. This also removes interactivity, which is a plus on the homepage. This PR introduces an alternative choice called "SimpleContact" - a static section that just displays contact methods pointing to "Other". It is recommended that this just has a shared mailbox if you've got one - one non-urgent contact and several urgent contacts is best.

<img width="478" height="440" alt="image" src="https://github.com/user-attachments/assets/6e7c8aef-dd80-4080-98a9-f9be16c65012" />

It also replaces the contact section within the default config, keeping in spirit with making the default config fairly simple and basic. It has also been added to the demo config, in addition to the normal contact section.

## What will existing users have to change when pulling these changes?
If you inherited from IStringProvider only (not recommended), then the new strings is a breaking change for you. You are advised to inherit from one of the supplied classes like StandardBritishEnglish.

## If you're changing existing functionality, is this change configurable?
Not Applicable - new functionality is disabled by default for existing users.

## Does any validation logic need adding/updating?
Yes, I have added validation to ensure that both sections aren't added at once.

## Are the strings configurable?
Yes.

## Any interesting design decisions?
I was going to add a new contact reason but I thought that was unnecessary and actually anything configured with Other encapsulates it quite well.

## Does this close any issues?
Closes #95