### PR TITLE
Show detailed claim status for registry items

### DIFF
--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -63,7 +63,7 @@
                     @foreach (var item in RegistryItems.Where(item => item.NumClaimsByUser(UserId) > 0))
                     {
                         <div class="gift">
-                            <RegistryItem Item="item" ButtonText="@(item.GetClaimByUser(UserId).IsCompleted ? StringProvider.Completed : StringProvider.Pending)" ButtonSuccess="@(!item.GetClaimByUser(UserId).IsCompleted)"/>
+                            <RegistryItem Item="item" State="@(item.GetClaimByUser(UserId).IsCompleted ? RegistryItemState.Completed : RegistryItemState.Pending)" ButtonSuccess="@(!item.GetClaimByUser(UserId).IsCompleted)"/>
                         </div>
                     }
                     <h2 class="grid-heading">@StringProvider.OtherRegistryItems</h2>
@@ -73,7 +73,7 @@
             @foreach (var item in SortedAndFilteredItems.Where(item => UserId == null || item.NumClaimsByUser(UserId) == 0 || IsSharedAccount))
             {
                 <div class="gift">
-                    <RegistryItem Item="item" ButtonText="@(item.IsFullyClaimed ? StringProvider.Claimed : StringProvider.Available)" ButtonSuccess="@(!item.IsFullyClaimed)"/>
+                    <RegistryItem Item="item" State="@(item.IsFullyClaimed ? RegistryItemState.Claimed : RegistryItemState.Available)" ButtonSuccess="@(!item.IsFullyClaimed)"/>
                 </div>
             }
             @if (!SortedAndFilteredItems.Any())

--- a/WeddingWebsite/Components/Pages/Registry/Registry.razor
+++ b/WeddingWebsite/Components/Pages/Registry/Registry.razor
@@ -73,7 +73,14 @@
             @foreach (var item in SortedAndFilteredItems.Where(item => UserId == null || item.NumClaimsByUser(UserId) == 0 || IsSharedAccount))
             {
                 <div class="gift">
-                    <RegistryItem Item="item" State="@(item.IsFullyClaimed ? RegistryItemState.Claimed : RegistryItemState.Available)" ButtonSuccess="@(!item.IsFullyClaimed)"/>
+                    <AuthorizeView Roles="Admin">
+                        <Authorized>
+                            <RegistryItem Item="item" State="@item.GetState()" ButtonSuccess="@(!item.IsFullyClaimed)"/>
+                        </Authorized>
+                        <NotAuthorized>
+                            <RegistryItem Item="item" State="@(item.IsFullyClaimed ? RegistryItemState.Claimed : RegistryItemState.Available)" ButtonSuccess="@(!item.IsFullyClaimed)"/>
+                        </NotAuthorized>
+                    </AuthorizeView>
                 </div>
             }
             @if (!SortedAndFilteredItems.Any())

--- a/WeddingWebsite/Components/WeddingComponents/RegistryItem.razor
+++ b/WeddingWebsite/Components/WeddingComponents/RegistryItem.razor
@@ -1,5 +1,7 @@
 ﻿@using WeddingWebsite.Components.Containers
+@using WeddingWebsite.Core
 @using WeddingWebsite.Models.ConfigInterfaces
+@using WeddingWebsite.Models.Registry
 @using WeddingWebsite.Models.Theme
 @using WeddingWebsite.Models.WebsiteConfig
 
@@ -17,7 +19,7 @@
             <p class="generic-name">@Item.GenericName</p>
             <h2>@Item.Name</h2>
             <div class="cost-and-button">
-                @if (ButtonText is "Pending" or "Completed" && Item.MaxQuantity > 1)
+                @if (State != RegistryItemState.Available && Item.MaxQuantity > 1)
                 {
                     <p><span class="cost">@StringProvider.CurrencyAmount(Item.Cost)</span> × @Item.QuantityClaimed</p>
                 } else if (Item.MaxQuantity-Item.QuantityClaimed > 1)
@@ -28,7 +30,7 @@
                 {
                     <p class="cost">@StringProvider.CurrencyAmount(Item.Cost)</p>
                 }
-                <button style="background: @ButtonColour;color: @ButtonTextColour">@ButtonText</button>
+                <button style="background: @ButtonColour;color: @ButtonTextColour">@State.GetEnumDescription()</button>
             </div>
 
         </ChildContent>
@@ -40,7 +42,7 @@
     public required Models.Registry.RegistryItem Item { get; set; }
     
     [Parameter]
-    public string ButtonText { get; set; } = "View";
+    public RegistryItemState State { get; set; } = RegistryItemState.Pending;
     
     [Parameter]
     public bool ButtonSuccess { get; set; } = true;

--- a/WeddingWebsite/Models/Registry/RegistryItem.cs
+++ b/WeddingWebsite/Models/Registry/RegistryItem.cs
@@ -41,4 +41,29 @@ public record RegistryItem(
         if (AllowMoneyTransfer) methods.Add(FulfillmentMethod.TransferMoney);
         return methods;
     }
+
+    /// <summary>
+    /// Obtains the state of this item, assuming the user is admin and has not claimed this item themselves.
+    /// </summary>
+    public RegistryItemState GetState()
+    {
+        if (!IsFullyClaimed)
+        {
+            // This has to be first otherwise the other conditions are vacuously true.
+            return RegistryItemState.Available;
+        }
+        if (Claims.All(claim => claim.IsReceived))
+        {
+            return RegistryItemState.Received;
+        }
+        if (Claims.All(claim => claim.IsCompleted))
+        {
+            return RegistryItemState.Completed;
+        }
+        if (Claims.All(claim => !claim.IsCompleted))
+        {
+            return RegistryItemState.Pending;
+        }
+        return RegistryItemState.Claimed;
+    }
 }

--- a/WeddingWebsite/Models/Registry/RegistryItemState.cs
+++ b/WeddingWebsite/Models/Registry/RegistryItemState.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+
+namespace WeddingWebsite.Models.Registry;
+
+/// <summary>
+/// The registry item state is a property of the item and a user who is looking at it. For example, if a user is not
+/// admin they will see 'Claimed' even if the status is actually 'Received'. If a user themselves claimed an item they
+/// may see the 'Pending' status, but other people would merely see 'Claimed'.
+/// </summary>
+public enum RegistryItemState
+{
+    [Description("Available")]
+    Available,
+    
+    [Description("Claimed")]
+    Claimed,
+    
+    [Description("Pending")]
+    Pending,
+    
+    [Description("Completed")]
+    Completed,
+    
+    [Description("Received")]
+    Received
+}


### PR DESCRIPTION
## What does this PR do, and why do we need it?
Admin users will now see "Claimed", "Pending", "Completed", or "Received" for registry items rather than just "Claimed". This makes it easier to manage which items are in what state.

<img width="270" height="347" alt="image" src="https://github.com/user-attachments/assets/cf1742e5-0718-4148-b23c-0e412424c21d" />

The original plan was to introduce a separate list view to easily manage these. This may be implemented in future, but for now the issue will be closed as this PR is likely to solve the root problem with less effort than the proposed solution in the issue.

## What will existing users have to change when pulling these changes?
Nothing

## If you're changing existing functionality, is this change configurable?
Not Configurable - Showing more information to admin users (that they can easily access through other means) is better. 

## Does any validation logic need adding/updating?
Nope.

## Are the strings configurable?
No, the strings are defined within an enum. This has been general practice to not bother making enum descriptions configurable.

## Any interesting design decisions?
Not really.

## Does this close any issues?
Closes #141